### PR TITLE
add initial support for .rst and pypi badge

### DIFF
--- a/howfairis/HowFairIsChecker.py
+++ b/howfairis/HowFairIsChecker.py
@@ -145,9 +145,9 @@ class HowFairIsChecker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMix
                                            self.branch, self.readme_filename)
         response = get_url(raw_url)
         if isinstance(response, requests.HTTPError):
-            #save the error of the first request
+            # Save the error of the first request
             first_error = f"{response}"
-            #try once more for .rst
+            # Try once more for .rst
             raw_url = raw_url[:-2] + "rst"
             response = get_url(raw_url)
             if isinstance(response, requests.HTTPError):

--- a/howfairis/mixins/ChecklistMixin.py
+++ b/howfairis/mixins/ChecklistMixin.py
@@ -17,8 +17,9 @@ class ChecklistMixin:
         if self.readme is None:
             self.print_state(check_name="has_sonarcloud_badge", state=False)
             return False
-        regex = r"!\[.*\]\(https://sonarcloud\.io/api/project_badges/.*\)\]" + \
-                r"\(https://sonarcloud\.io/dashboard\?id=.*\)"
-        r = re.compile(regex).search(self.readme) is not None
+        regex1 = r"https://sonarcloud\.io/api/project_badges/.*"
+        regex2 = r"https://sonarcloud\.io/dashboard\?id=.*"
+        r = re.compile(regex1).search(self.readme) is not None
+        r = r and re.compile(regex2).search(self.readme) is not None
         self.print_state(check_name="has_sonarcloud_badge", state=r)
         return r

--- a/howfairis/mixins/RegistryMixin.py
+++ b/howfairis/mixins/RegistryMixin.py
@@ -42,9 +42,10 @@ class RegistryMixin:
         if self.readme is None:
             self.print_state(check_name="has_pypi_badge", state=False)
             return False
-        regex = r"!\[.*\]\(https://img\.shields\.io/pypi/v/[^.]*\.svg.*\)\]" + \
-                r"\(https://pypi\.python\.org/pypi/.*\)"
-        r = re.compile(regex).search(self.readme) is not None
+        regex1 = r"https://img\.shields\.io/pypi/v/[^.]*\.svg"
+        regex2 = r"https://pypi\.python\.org/pypi/"
+        r = re.compile(regex1).search(self.readme) is not None
+        r = r and re.compile(regex2).search(self.readme) is not None
         self.print_state(check_name="has_pypi_badge", state=r)
         return r
 


### PR DESCRIPTION
As per title. Changed the pypi badge checker to only check for the URLs not the ``[]()`` around it. Also, when fetching the README.md results in a 404 error it will try once more on README.rst. 