### PR TITLE
Click and config

### DIFF
--- a/howfairis/HowFairIsChecker.py
+++ b/howfairis/HowFairIsChecker.py
@@ -1,6 +1,5 @@
 import sys
 import re
-import os
 import inspect
 import yaml
 import requests

--- a/howfairis/__init__.py
+++ b/howfairis/__init__.py
@@ -1,5 +1,6 @@
 from . import mixins
 from .HowFairIsChecker import HowFairIsChecker
+from .__version__ import __version__
 
 
 __author__ = "https://github.com/jspaaks"
@@ -7,5 +8,6 @@ __email__ = 'j.spaaks@esciencecenter.nl'
 
 __all__ = [
     "HowFairIsChecker",
-    "mixins"
+    "mixins",
+    "__version__"
 ]

--- a/howfairis/cli.py
+++ b/howfairis/cli.py
@@ -2,22 +2,33 @@ import sys
 from colorama import init as init_terminal_colors
 import click
 from howfairis import HowFairIsChecker
+from howfairis import __version__
 
 
 @click.command()
-@click.argument("url")
-@click.option("-c", "--config-file", default=None, help="Config file. Default: .howfairis.yml", type=click.Path())
 @click.option("-b", "--branch", default="master", help="Which git branch to use. Default: master")
+@click.option("-c", "--config-file", default=None, help="Config file. Default: .howfairis.yml", type=click.Path())
 @click.option("-p", "--path", default="", help="Relative path to the readme. Default: empty")
 @click.option("-s", "--show-trace", default=False, help="Show full traceback on errors. Default: False", is_flag=True)
-def cli(url, config_file=".howfairis.yml", branch=None, path=None, show_trace=False):
+@click.option("-v", "--version", default=False, help="Show version", is_flag=True)
+@click.argument("url", nargs=-1)
+def cli(url=None, config_file=".howfairis.yml", branch=None, path=None, show_trace=False, version=None):
     """Determine compliance with recommendations from fair-software.eu for the GitHub repository at URL."""
+
+    if version is True:
+        print("version: {0}".format(__version__))
+        return
     if show_trace is False:
         sys.tracebacklimit = 0
+
     init_terminal_colors()
+
+    if len(url) != 1:
+        raise ValueError("Expected exactly one value for input argument URL.")
+
     print("Checking compliance with fair-software.eu...")
-    print("Running for {0}/{1}/{2}".format(url, branch, path.strip("/")))
-    checker = HowFairIsChecker(url, config_file, branch, path)
+    print("Running for {0}/{1}/{2}".format(url[0], branch, path.strip("/")))
+    checker = HowFairIsChecker(url[0], config_file, branch, path)
     checker.check_five_recommendations()
     checker.check_badge()
 

--- a/howfairis/cli.py
+++ b/howfairis/cli.py
@@ -1,24 +1,23 @@
 import sys
 from colorama import init as init_terminal_colors
-
+import click
 from howfairis import HowFairIsChecker
 
 
-def cli():
-
+@click.command()
+@click.argument("url")
+@click.option("-c", "--config-file", default=None, help="Config file. Default: .howfairis.yml", type=click.Path())
+@click.option("-b", "--branch", default="master", help="Which git branch to use. Default: master")
+@click.option("-p", "--path", default="", help="Relative path to the readme. Default: empty")
+@click.option("-s", "--show-trace", default=False, help="Show full traceback on errors. Default: False", is_flag=True)
+def cli(url, config_file=".howfairis.yml", branch=None, path=None, show_trace=False):
+    """Determine compliance with recommendations from fair-software.eu for the GitHub repository at URL."""
+    if show_trace is False:
+        sys.tracebacklimit = 0
     init_terminal_colors()
-
     print("Checking compliance with fair-software.eu...")
-
-    if len(sys.argv) != 2:
-        raise Exception("Expected exactly one argument, i.e. the URL for " +
-                        "which GitHub repository to run the analysis.")
-
-    url = sys.argv[1]
-    print("Running for {0}".format(url))
-    checker = HowFairIsChecker(url)
-    checker.deconstruct_url()
-    checker.get_readme()
+    print("Running for {0}/{1}/{2}".format(url, branch, path.strip("/")))
+    checker = HowFairIsChecker(url, config_file, branch, path)
     checker.check_five_recommendations()
     checker.check_badge()
 

--- a/howfairis/cli.py
+++ b/howfairis/cli.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-arguments
 import sys
 from colorama import init as init_terminal_colors
 import click
@@ -12,7 +13,8 @@ from howfairis import __version__
 @click.option("-s", "--show-trace", default=False, help="Show full traceback on errors. Default: False", is_flag=True)
 @click.option("-v", "--version", default=False, help="Show version", is_flag=True)
 @click.argument("url", nargs=-1)
-def cli(url=None, config_file=".howfairis.yml", branch=None, path=None, show_trace=False, version=None):
+def cli(url=None, config_file=".howfairis.yml", branch=None,
+        path=None, show_trace=False, version=None):
     """Determine compliance with recommendations from fair-software.eu for the GitHub repository at URL."""
 
     if version is True:

--- a/howfairis/mixins/ChecklistMixin.py
+++ b/howfairis/mixins/ChecklistMixin.py
@@ -1,12 +1,22 @@
 class ChecklistMixin:
 
     def check_checklist(self):
-        print("(5/5) checklist")
-        results = [
-            self.has_core_infrastructures_badge(),
-            self.has_sonarcloud_badge()
-        ]
-        return True in results
+        force = self.config.get("force", dict())
+        if not isinstance(force, dict):
+            force = dict()
+        force_state = force.get("checklist")
+        if force_state not in [True, False, None]:
+            raise ValueError("Unexpected configuration value for force.checklist.")
+        elif isinstance(force_state, bool):
+            print("(5/5) checklist: force {0}".format(force_state))
+            return force_state
+        else:
+            print("(5/5) checklist")
+            results = [
+                self.has_core_infrastructures_badge(),
+                self.has_sonarcloud_badge()
+            ]
+            return True in results
 
     def has_core_infrastructures_badge(self):
         regexes = [r"https://bestpractices\.coreinfrastructure\.org/projects/[0-9]*/badge"]

--- a/howfairis/mixins/ChecklistMixin.py
+++ b/howfairis/mixins/ChecklistMixin.py
@@ -7,16 +7,15 @@ class ChecklistMixin:
         force_state = force.get("checklist")
         if force_state not in [True, False, None]:
             raise ValueError("Unexpected configuration value for force.checklist.")
-        elif isinstance(force_state, bool):
+        if isinstance(force_state, bool):
             print("(5/5) checklist: force {0}".format(force_state))
             return force_state
-        else:
-            print("(5/5) checklist")
-            results = [
-                self.has_core_infrastructures_badge(),
-                self.has_sonarcloud_badge()
-            ]
-            return True in results
+        print("(5/5) checklist")
+        results = [
+            self.has_core_infrastructures_badge(),
+            self.has_sonarcloud_badge()
+        ]
+        return True in results
 
     def has_core_infrastructures_badge(self):
         regexes = [r"https://bestpractices\.coreinfrastructure\.org/projects/[0-9]*/badge"]

--- a/howfairis/mixins/CitationMixin.py
+++ b/howfairis/mixins/CitationMixin.py
@@ -4,27 +4,37 @@ import requests
 class CitationMixin:
 
     def check_citation(self):
-        print("(4/5) citation")
-        results = [
-            self.has_citation_file(),
-            self.has_citationcff_file(),
-            self.has_codemeta_file(),
-            self.has_zenodo_badge(),
-            self.has_zenodo_metadata_file()
-        ]
-        return True in results
+        force = self.config.get("force", dict())
+        if not isinstance(force, dict):
+            force = dict()
+        force_state = force.get("citation")
+        if force_state not in [True, False, None]:
+            raise ValueError("Unexpected configuration value for force.citation.")
+        elif isinstance(force_state, bool):
+            print("(4/5) citation: force {0}".format(force_state))
+            return force_state
+        else:
+            print("(4/5) citation")
+            results = [
+                self.has_citation_file(),
+                self.has_citationcff_file(),
+                self.has_codemeta_file(),
+                self.has_zenodo_badge(),
+                self.has_zenodo_metadata_file()
+            ]
+            return True in results
 
     def has_citation_file(self):
         url = "https://raw.githubusercontent.com/" + \
-              "{0}/{1}/{2}/CITATION".format(self.owner, self.repo, self.branch)
+              "{0}/{1}/{2}/{3}/CITATION".format(self.owner, self.repo, self.branch, self.path)
         try:
             response = requests.get(url)
             # If the response was successful, no Exception will be raised
             response.raise_for_status()
         except requests.HTTPError:
-            self.print_state(check_name="has_citation_file", state=False)
+            self._print_state(check_name="has_citation_file", state=False)
             return False
-        self.print_state(check_name="has_citation_file", state=True)
+        self._print_state(check_name="has_citation_file", state=True)
         return True
 
     def has_citationcff_file(self):
@@ -35,9 +45,9 @@ class CitationMixin:
             # If the response was successful, no Exception will be raised
             response.raise_for_status()
         except requests.HTTPError:
-            self.print_state(check_name="has_citationcff_file", state=False)
+            self._print_state(check_name="has_citationcff_file", state=False)
             return False
-        self.print_state(check_name="has_citationcff_file", state=True)
+        self._print_state(check_name="has_citationcff_file", state=True)
         return True
 
     def has_codemeta_file(self):
@@ -48,9 +58,9 @@ class CitationMixin:
             # If the response was successful, no Exception will be raised
             response.raise_for_status()
         except requests.HTTPError:
-            self.print_state(check_name="has_codemeta_file", state=False)
+            self._print_state(check_name="has_codemeta_file", state=False)
             return False
-        self.print_state(check_name="has_codemeta_file", state=True)
+        self._print_state(check_name="has_codemeta_file", state=True)
         return True
 
     def has_zenodo_badge(self):
@@ -66,7 +76,7 @@ class CitationMixin:
             # If the response was successful, no Exception will be raised
             response.raise_for_status()
         except requests.HTTPError:
-            self.print_state(check_name="has_zenodo_metadata_file", state=False)
+            self._print_state(check_name="has_zenodo_metadata_file", state=False)
             return False
-        self.print_state(check_name="has_zenodo_metadata_file", state=True)
+        self._print_state(check_name="has_zenodo_metadata_file", state=True)
         return True

--- a/howfairis/mixins/CitationMixin.py
+++ b/howfairis/mixins/CitationMixin.py
@@ -10,19 +10,18 @@ class CitationMixin:
         force_state = force.get("citation")
         if force_state not in [True, False, None]:
             raise ValueError("Unexpected configuration value for force.citation.")
-        elif isinstance(force_state, bool):
+        if isinstance(force_state, bool):
             print("(4/5) citation: force {0}".format(force_state))
             return force_state
-        else:
-            print("(4/5) citation")
-            results = [
-                self.has_citation_file(),
-                self.has_citationcff_file(),
-                self.has_codemeta_file(),
-                self.has_zenodo_badge(),
-                self.has_zenodo_metadata_file()
-            ]
-            return True in results
+        print("(4/5) citation")
+        results = [
+            self.has_citation_file(),
+            self.has_citationcff_file(),
+            self.has_codemeta_file(),
+            self.has_zenodo_badge(),
+            self.has_zenodo_metadata_file()
+        ]
+        return True in results
 
     def has_citation_file(self):
         url = "https://raw.githubusercontent.com/" + \

--- a/howfairis/mixins/LicenseMixin.py
+++ b/howfairis/mixins/LicenseMixin.py
@@ -4,9 +4,19 @@ import requests
 class LicenseMixin:
 
     def check_license(self):
-        print("(2/5) license")
-        results = [self.has_license()]
-        return True in results
+        force = self.config.get("force", dict())
+        if not isinstance(force, dict):
+            force = dict()
+        force_state = force.get("license")
+        if force_state not in [True, False, None]:
+            raise ValueError("Unexpected configuration value for force.license.")
+        elif isinstance(force_state, bool):
+            print("(2/5) license: force {0}".format(force_state))
+            return force_state
+        else:
+            print("(2/5) license")
+            results = [self.has_open_repository()]
+            return True in results
 
     def has_license(self):
         url = "https://api.github.com/repos/{0}/{1}/license".format(self.owner, self.repo)
@@ -15,7 +25,7 @@ class LicenseMixin:
             # If the response was successful, no Exception will be raised
             response.raise_for_status()
         except requests.HTTPError:
-            self.print_state(check_name="has_license", state=False)
+            self._print_state(check_name="has_license", state=False)
             return False
-        self.print_state(check_name="has_license", state=True)
+        self._print_state(check_name="has_license", state=True)
         return True

--- a/howfairis/mixins/LicenseMixin.py
+++ b/howfairis/mixins/LicenseMixin.py
@@ -10,13 +10,12 @@ class LicenseMixin:
         force_state = force.get("license")
         if force_state not in [True, False, None]:
             raise ValueError("Unexpected configuration value for force.license.")
-        elif isinstance(force_state, bool):
+        if isinstance(force_state, bool):
             print("(2/5) license: force {0}".format(force_state))
             return force_state
-        else:
-            print("(2/5) license")
-            results = [self.has_open_repository()]
-            return True in results
+        print("(2/5) license")
+        results = [self.has_open_repository()]
+        return True in results
 
     def has_license(self):
         url = "https://api.github.com/repos/{0}/{1}/license".format(self.owner, self.repo)

--- a/howfairis/mixins/RegistryMixin.py
+++ b/howfairis/mixins/RegistryMixin.py
@@ -10,23 +10,22 @@ class RegistryMixin:
         force_state = force.get("registry")
         if force_state not in [True, False, None]:
             raise ValueError("Unexpected configuration value for force.registry.")
-        elif isinstance(force_state, bool):
+        if isinstance(force_state, bool):
             print("(3/5) registry: force {0}".format(force_state))
             return force_state
-        else:
-            print("(3/5) registry")
-            results = [
-                self.has_bintray_badge(),
-                self.has_conda_badge(),
-                self.has_cran_badge(),
-                self.has_crates_badge(),
-                self.has_maven_badge(),
-                self.has_npm_badge(),
-                self.has_pypi_badge(),
-                self.has_rsd_badge(),
-                self.is_on_github_marketplace()
-            ]
-            return True in results
+        print("(3/5) registry")
+        results = [
+            self.has_bintray_badge(),
+            self.has_conda_badge(),
+            self.has_cran_badge(),
+            self.has_crates_badge(),
+            self.has_maven_badge(),
+            self.has_npm_badge(),
+            self.has_pypi_badge(),
+            self.has_rsd_badge(),
+            self.is_on_github_marketplace()
+        ]
+        return True in results
 
     def has_bintray_badge(self):
         regexes = [r"https://api\.bintray\.com/packages/.*/.*/.*/images/download\.svg",

--- a/howfairis/mixins/RegistryMixin.py
+++ b/howfairis/mixins/RegistryMixin.py
@@ -4,19 +4,29 @@ import requests
 class RegistryMixin:
 
     def check_registry(self):
-        print("(3/5) registry")
-        results = [
-            self.has_bintray_badge(),
-            self.has_conda_badge(),
-            self.has_cran_badge(),
-            self.has_crates_badge(),
-            self.has_maven_badge(),
-            self.has_npm_badge(),
-            self.has_pypi_badge(),
-            self.has_rsd_badge(),
-            self.is_on_github_marketplace()
-        ]
-        return True in results
+        force = self.config.get("force", dict())
+        if not isinstance(force, dict):
+            force = dict()
+        force_state = force.get("registry")
+        if force_state not in [True, False, None]:
+            raise ValueError("Unexpected configuration value for force.registry.")
+        elif isinstance(force_state, bool):
+            print("(3/5) registry: force {0}".format(force_state))
+            return force_state
+        else:
+            print("(3/5) registry")
+            results = [
+                self.has_bintray_badge(),
+                self.has_conda_badge(),
+                self.has_cran_badge(),
+                self.has_crates_badge(),
+                self.has_maven_badge(),
+                self.has_npm_badge(),
+                self.has_pypi_badge(),
+                self.has_rsd_badge(),
+                self.is_on_github_marketplace()
+            ]
+            return True in results
 
     def has_bintray_badge(self):
         regexes = [r"https://api\.bintray\.com/packages/.*/.*/.*/images/download\.svg",
@@ -69,11 +79,11 @@ class RegistryMixin:
             # If the response was successful, no Exception will be raised
             response.raise_for_status()
         except requests.HTTPError:
-            self.print_state(check_name="is_on_github_marketplace", state=False)
+            self._print_state(check_name="is_on_github_marketplace", state=False)
             return False
 
         html = response.text
         r = "Use this GitHub Action with your project" in html and \
             "Add this Action to an existing workflow or create a new one." in html
-        self.print_state(check_name="is_on_github_marketplace", state=r)
+        self._print_state(check_name="is_on_github_marketplace", state=r)
         return r

--- a/howfairis/mixins/RepositoryMixin.py
+++ b/howfairis/mixins/RepositoryMixin.py
@@ -10,13 +10,12 @@ class RepositoryMixin:
         force_state = force.get("repository")
         if force_state not in [True, False, None]:
             raise ValueError("Unexpected configuration value for force.repository.")
-        elif isinstance(force_state, bool):
+        if isinstance(force_state, bool):
             print("(1/5) repository: force {0}".format(force_state))
             return force_state
-        else:
-            print("(1/5) repository")
-            results = [self.has_open_repository()]
-            return True in results
+        print("(1/5) repository")
+        results = [self.has_open_repository()]
+        return True in results
 
     def has_open_repository(self):
         url = "https://api.github.com/repos/{0}/{1}".format(self.owner, self.repo)

--- a/howfairis/mixins/RepositoryMixin.py
+++ b/howfairis/mixins/RepositoryMixin.py
@@ -4,9 +4,19 @@ import requests
 class RepositoryMixin:
 
     def check_repository(self):
-        print("(1/5) repository")
-        results = [self.has_open_repository()]
-        return True in results
+        force = self.config.get("force", dict())
+        if not isinstance(force, dict):
+            force = dict()
+        force_state = force.get("repository")
+        if force_state not in [True, False, None]:
+            raise ValueError("Unexpected configuration value for force.repository.")
+        elif isinstance(force_state, bool):
+            print("(1/5) repository: force {0}".format(force_state))
+            return force_state
+        else:
+            print("(1/5) repository")
+            results = [self.has_open_repository()]
+            return True in results
 
     def has_open_repository(self):
         url = "https://api.github.com/repos/{0}/{1}".format(self.owner, self.repo)
@@ -16,9 +26,9 @@ class RepositoryMixin:
             # If the response was successful, no Exception will be raised
             response.raise_for_status()
         except requests.HTTPError:
-            self.print_state(check_name="has_open_repository", state=False)
+            self._print_state(check_name="has_open_repository", state=False)
             return False
         except Exception as err:
             print(f"Other error occurred: {err}")
-        self.print_state(check_name="has_open_repository", state=True)
+        self._print_state(check_name="has_open_repository", state=True)
         return True

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,8 @@ setup(
     install_requires=[
         "click>=7",
         "colorama>=0",
-        "PyYAML>=5"
-        "requests>=2",
+        "PyYAML>=5",
+        "requests>=2"
     ],
     setup_requires=[
     ],

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,10 @@ setup(
     ],
     test_suite="tests",
     install_requires=[
-        "requests",
-        "colorama"
+        "click>=7",
+        "colorama>=0",
+        "PyYAML>=5"
+        "requests>=2",
     ],
     setup_requires=[
     ],


### PR DESCRIPTION
This PR adds 

- a ``Click``-based command line interface with ``--help``
- reading of a config file (from the remote) refs #14
- forcing any of the 5 aspects ``true`` or ``false`` refs #14
- doing the analysis on a branch (from the remote)
- doing the analysis on a subdirectory (from the remote)
