### PR TITLE
Config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,26 +144,26 @@ Which then shows something like:
       GitHub or GitLab repository at URL.
 
     Options:
-      -b, --branch TEXT               Which git branch to use.
-      -c, --config-file PATH          Name of the configuration file to control
-                                      howfairis'es behavior. The configuration
-                                      file needs to be on the remote, and takes
-                                      into account the value of --branch and
-                                      --path. Default: .howfairis.yml
+      -b, --branch TEXT              Which git branch to use.
+      -c, --config-file PATH         Name of the configuration file to control
+                                     howfairis'es behavior. The configuration file
+                                     needs to be present on the local system and
+                                     can include a relative path.
 
-      -d, --show-default-config       Show default configuration and exit.
-      -i, --include-comments [yes|no]
-                                      When looking for badges, include sections of
-                                      the README that have been commented out
-                                      using <!-- and -->. Default: no
+      -d, --show-default-config      Show default configuration and exit.
+      -p, --path TEXT                Relative path (on the remote). Use this if
+                                     you want howfairis to look for a README and a
+                                     configuration file in a subdirectory.
 
-      -p, --path TEXT                 Relative path (on the remote). Use this if
-                                      you want howfairis to look for a README in a
-                                      subdirectory.
+      -r, --remote-config-file TEXT  Name of the configuration file to control
+                                     howfairis'es behavior. The configuration file
+                                     needs to be on the remote, and takes into
+                                     account the value of --branch and --path.
+                                     Default: .howfairis.yml
 
-      -t, --show-trace [yes|no]       Show full traceback on errors. Default: no
-      -v, --version                   Show version and exit.
-      -h, --help                      Show this message and exit.
+      -t, --show-trace [yes|no]      Show full traceback on errors. Default: no
+      -v, --version                  Show version and exit.
+      -h, --help                     Show this message and exit.
 
 Configuration file
 ^^^^^^^^^^^^^^^^^^
@@ -176,13 +176,11 @@ The configuration file should follow the voluptuous_ schema laid out in schema.p
 .. code:: python
 
     schema = {
-        Optional("force"): Any({
-            Optional("repository"): Any(bool, None),
-            Optional("license"): Any(bool, None),
-            Optional("registry"): Any(bool, None),
-            Optional("citation"): Any(bool, None),
-            Optional("checklist"): Any(bool, None),
-        }, None),
+        Optional("force_repository"): Any(bool, None),
+        Optional("force_license"): Any(bool, None),
+        Optional("force_registry"): Any(bool, None),
+        Optional("force_citation"): Any(bool, None),
+        Optional("force_checklist"): Any(bool, None),
         Optional("include_comments"): Any(bool, None)
     }
 
@@ -190,9 +188,8 @@ For example, the following is a valid configuration file document:
 
 .. code:: yaml
 
-    force:
-      registry: true  # It is good practice to add an explanation
-                      # of why you chose to set the state manually
+    force_registry: true  # It is good practice to add an explanation
+                          # of why you chose to set the state manually
 
 The manual override will be reflected in the output, as follows:
 

--- a/clitests/script.sh
+++ b/clitests/script.sh
@@ -14,22 +14,34 @@ howfairis --show-default-config
 DURATION=10
 
 # github
-howfairis https://github.com/fair-software/badge-test && sleep $DURATION
-howfairis https://github.com/fair-software/badge-test -p force/00100 && sleep $DURATION
-howfairis https://github.com/fair-software/badge-test -p force/10110 && sleep $DURATION
-howfairis https://github.com/fair-software/badge-test -p force/11110 && sleep $DURATION
-howfairis https://github.com/fair-software/badge-test -p force/11111 && sleep $DURATION
-howfairis https://github.com/fair-software/badge-test -p force/uu1uu && sleep $DURATION
-howfairis https://github.com/fair-software/badge-test -p force/u && sleep $DURATION
-howfairis https://github.com/fair-software/badge-test -p include_comments && sleep $DURATION
+howfairis https://github.com/fair-software/badge-test
+sleep $DURATION
+howfairis https://github.com/fair-software/badge-test -p force/00100
+sleep $DURATION
+howfairis https://github.com/fair-software/badge-test -p force/10110
+sleep $DURATION
+howfairis https://github.com/fair-software/badge-test -p force/11110
+sleep $DURATION
+howfairis https://github.com/fair-software/badge-test -p force/11111
+sleep $DURATION
+howfairis https://github.com/fair-software/badge-test -p force/uu1uu
+sleep $DURATION
+howfairis https://github.com/fair-software/badge-test -p include_comments
+sleep $DURATION
 
 
 # gitlab
-howfairis https://gitlab.com/jspaaks/badge-test && sleep $DURATION
-howfairis https://gitlab.com/jspaaks/badge-test -p force/00100 && sleep $DURATION
-howfairis https://gitlab.com/jspaaks/badge-test -p force/10110 && sleep $DURATION
-howfairis https://gitlab.com/jspaaks/badge-test -p force/11110 && sleep $DURATION
-howfairis https://gitlab.com/jspaaks/badge-test -p force/11111 && sleep $DURATION
-howfairis https://gitlab.com/jspaaks/badge-test -p force/uu1uu && sleep $DURATION
-howfairis https://gitlab.com/jspaaks/badge-test -p force/u && sleep $DURATION
-howfairis https://gitlab.com/jspaaks/badge-test -p include_comments && sleep $DURATION
+howfairis https://gitlab.com/jspaaks/badge-test
+sleep $DURATION
+howfairis https://gitlab.com/jspaaks/badge-test -p force/00100
+sleep $DURATION
+howfairis https://gitlab.com/jspaaks/badge-test -p force/10110
+sleep $DURATION
+howfairis https://gitlab.com/jspaaks/badge-test -p force/11110
+sleep $DURATION
+howfairis https://gitlab.com/jspaaks/badge-test -p force/11111
+sleep $DURATION
+howfairis https://gitlab.com/jspaaks/badge-test -p force/uu1uu
+sleep $DURATION
+howfairis https://gitlab.com/jspaaks/badge-test -p include_comments
+sleep $DURATION

--- a/clitests/script.sh
+++ b/clitests/script.sh
@@ -11,7 +11,7 @@ howfairis --help
 howfairis --version
 howfairis --show-default-config
 
-DURATION=10
+DURATION=20
 
 # github
 howfairis https://github.com/fair-software/badge-test

--- a/howfairis/Checker.py
+++ b/howfairis/Checker.py
@@ -14,11 +14,12 @@ from howfairis.ReadmeFormat import ReadmeFormat
 
 
 class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, ChecklistMixin):
-    def __init__(self, config=None):
+    def __init__(self, config, repo):
         super().__init__()
         self.compliance = None
         self.config = config
         self.readme = None
+        self.repo = repo
 
         self._get_readme()
 
@@ -41,7 +42,7 @@ class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, Check
             return re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
 
         for readme_filename in ["README.rst", "README.md"]:
-            raw_url = self.config.repo.raw_url_format_string.format(readme_filename)
+            raw_url = self.repo.raw_url_format_string.format(readme_filename)
             try:
                 response = requests.get(raw_url)
                 # If the response was successful, no Exception will be raised
@@ -56,7 +57,7 @@ class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, Check
             else:
                 readme_fmt = None
 
-            if self.config.yamldata.get("include_comments") is True:
+            if self.config.merged.get("include_comments") is True:
                 text = response.text
             else:
                 text = remove_comments(response.text)

--- a/howfairis/Config.py
+++ b/howfairis/Config.py
@@ -7,9 +7,9 @@ from howfairis.schema import validate_against_schema
 
 
 class Config:
-    def __init__(self, repo, config_filename=None):
+    def __init__(self, repo, config_filename=None, ignore_remote_config=False):
         self.default = Config._load_default_config()
-        self.repo = Config._load_repo_config(repo)
+        self.repo = Config._load_repo_config(repo, ignore_remote_config)
         self.user = Config._load_user_config(config_filename)
 
     @staticmethod
@@ -29,8 +29,11 @@ class Config:
         return default_config
 
     @staticmethod
-    def _load_repo_config(repo):
+    def _load_repo_config(repo, ignore_remote_config):
         if repo is None:
+            return dict()
+
+        if ignore_remote_config is True:
             return dict()
 
         if repo.config_file is None:

--- a/howfairis/Config.py
+++ b/howfairis/Config.py
@@ -65,7 +65,7 @@ class Config:
 
         p = os.path.join(os.getcwd(), config_filename)
         if not os.path.exists(p):
-            raise FileNotFoundError("{0} doesn't exist.")
+            raise FileNotFoundError("{0} doesn't exist.".format(config_filename))
 
         with open(p, "rt") as f:
             text = f.read()

--- a/howfairis/Config.py
+++ b/howfairis/Config.py
@@ -1,9 +1,9 @@
 import os
 import requests
 from ruamel.yaml import YAML
-from howfairis.schema import validate_against_schema
 from voluptuous.error import Invalid
 from voluptuous.error import MultipleInvalid
+from howfairis.schema import validate_against_schema
 
 
 class Config:

--- a/howfairis/Config.py
+++ b/howfairis/Config.py
@@ -62,10 +62,10 @@ class Config:
     def _load_user_config(config_filename):
         if config_filename is None:
             return dict()
-        else:
-            p = os.path.join(os.getcwd(), config_filename)
-            if not os.path.exists(p):
-                raise FileNotFoundError("{0} doesn't exist.")
+
+        p = os.path.join(os.getcwd(), config_filename)
+        if not os.path.exists(p):
+            raise FileNotFoundError("{0} doesn't exist.")
 
         with open(p, "rt") as f:
             text = f.read()

--- a/howfairis/Config.py
+++ b/howfairis/Config.py
@@ -2,7 +2,8 @@ import os
 import requests
 from ruamel.yaml import YAML
 from howfairis.schema import validate_against_schema
-from voluptuous.error import MultipleInvalid, Invalid
+from voluptuous.error import Invalid
+from voluptuous.error import MultipleInvalid
 
 
 class Config:

--- a/howfairis/Config.py
+++ b/howfairis/Config.py
@@ -5,69 +5,83 @@ from howfairis.schema import validate_against_schema
 
 
 class Config:
-    def __init__(self, repo, config_filename=None, include_comments=None):
-        self.repo = repo
-        self.has_user_input = config_filename is not None
-        self.yamldata = None
+    def __init__(self, repo, config_filename=None):
+        self.default = Config._load_default_config()
+        self.repo = Config._load_repo_config(repo)
+        self.user = Config._load_user_config(config_filename)
 
-        self._load_default_config()
-        self._load_repo_config(config_filename)
-        self._load_cli_config(include_comments)
-
-    def _load_cli_config(self, include_comments):
-        if include_comments == "yes":
-            d = dict(include_comments=True)
-        elif include_comments == "no":
-            d = dict(include_comments=False)
-        else:
-            d = dict()
-        self.yamldata.update(d)
-        return self
-
-    def _load_default_config(self):
-
+    @staticmethod
+    def _load_default_config():
         pkg_root = os.path.dirname(__file__)
         config_filename = os.path.join(pkg_root, "data", ".howfairis.yml")
         with open(config_filename, "rt") as f:
             text = f.read()
-        newdata = YAML(typ="safe").load(text)
-        if newdata is None:
-            newdata = dict()
+        default_config = YAML(typ="safe").load(text)
+        if default_config is None:
+            default_config = dict()
         try:
-            validate_against_schema(newdata)
+            validate_against_schema(default_config)
         except Exception as e:
             raise Exception("Default configuration file should follow the schema.") from e
-        self.yamldata = newdata
-        return self
+        return default_config
 
-    def _load_repo_config(self, config_filename):
-        if self.repo is None:
-            return self
+    @staticmethod
+    def _load_repo_config(repo):
+        if repo is None:
+            return dict()
 
-        if config_filename is None:
+        if repo.config_file is None:
             config_filename = ".howfairis.yml"
+        else:
+            config_filename = repo.config_file
 
-        raw_url = self.repo.raw_url_format_string.format(config_filename)
+        raw_url = repo.raw_url_format_string.format(config_filename)
         try:
             response = requests.get(raw_url)
             # If the response was successful, no Exception will be raised
             response.raise_for_status()
             print("Using the configuration file {0}".format(raw_url))
         except requests.HTTPError as e:
-            if self.has_user_input:
+            if repo.config_file is not None:
                 raise Exception("Could not find the configuration file {0}".format(raw_url)) from e
-            return self
+            return dict()
 
         try:
-            newdata = YAML(typ="safe").load(response.text)
+            repo_config = YAML(typ="safe").load(response.text)
         except Exception as e:
             raise Exception("Problem loading YAML configuration from file {0}".format(raw_url)) from e
 
         try:
-            validate_against_schema(newdata)
+            validate_against_schema(repo_config)
         except Exception as e:
             raise Exception("Configuration file should follow the schema.") from e
 
-        self.yamldata.update(newdata)
+        return repo_config
 
-        return self
+    @staticmethod
+    def _load_user_config(config_filename):
+        if config_filename is None:
+            return dict()
+        else:
+            p = os.path.join(os.getcwd(), config_filename)
+            if not os.path.exists(p):
+                raise FileNotFoundError("{0} doesn't exist.")
+
+        with open(p, "rt") as f:
+            text = f.read()
+        user_config = YAML(typ="safe").load(text)
+        if user_config is None:
+            user_config = dict()
+        try:
+            validate_against_schema(user_config)
+        except Exception as e:
+            raise Exception("User configuration file should follow the schema.") from e
+        return user_config
+
+    @property
+    def merged(self):
+        m = dict()
+        m.update(self.default)
+        m.update(self.repo)
+        m.update(self.user)
+        return m

--- a/howfairis/Config.py
+++ b/howfairis/Config.py
@@ -2,6 +2,7 @@ import os
 import requests
 from ruamel.yaml import YAML
 from howfairis.schema import validate_against_schema
+from voluptuous.error import MultipleInvalid, Invalid
 
 
 class Config:
@@ -21,8 +22,9 @@ class Config:
             default_config = dict()
         try:
             validate_against_schema(default_config)
-        except Exception as e:
-            raise Exception("Default configuration file should follow the schema.") from e
+        except (Invalid, MultipleInvalid):
+            print("Default configuration file should follow the schema for it to be considered.")
+            return dict()
         return default_config
 
     @staticmethod
@@ -53,8 +55,9 @@ class Config:
 
         try:
             validate_against_schema(repo_config)
-        except Exception as e:
-            raise Exception("Configuration file should follow the schema.") from e
+        except (Invalid, MultipleInvalid):
+            print("Repository's configuration file should follow the schema for it to be considered.")
+            return dict()
 
         return repo_config
 

--- a/howfairis/Repo.py
+++ b/howfairis/Repo.py
@@ -2,15 +2,16 @@ from .Platform import Platform
 
 
 class Repo:
-    def __init__(self, url, branch=None, path=None):
-        self.url = url
-        self.branch = "master" if branch is None else branch
-        self.path = "" if path is None else "/" + path.strip("/")
+    def __init__(self, url, branch=None, path=None, config_file=None):
         self.api = None
+        self.branch = "master" if branch is None else branch
+        self.config_file = config_file
         self.owner = None
+        self.path = "" if path is None else "/" + path.strip("/")
         self.platform = None
         self.raw_url_format_string = None
         self.repo = None
+        self.url = url
 
         self._deconstruct_url()
 

--- a/howfairis/cli.py
+++ b/howfairis/cli.py
@@ -52,23 +52,24 @@ def check_badge(compliance, readme=None):
               help="Which git branch to use.")
 @click.option("-c", "--config-file", default=None, type=click.Path(),
               help="Name of the configuration file to control howfairis'es behavior. The configuration " +
-                   "file needs to be on the remote, and takes into account the value of " +
-                   "--branch and --path. Default: .howfairis.yml")
+                   "file needs to be present on the local system and can include a relative path.")
 @click.option("-d", "--show-default-config", default=False, is_flag=True,
               help="Show default configuration and exit.")
-@click.option("-i", "--include-comments", default=None, type=click.Choice(["yes", "no"], case_sensitive=True),
-              help="When looking for badges, include sections of the README that " +
-              "have been commented out using <!-- and -->. Default: no")
 @click.option("-p", "--path", default=None, type=click.STRING,
               help="Relative path (on the remote). Use this if you want howfairis to look for a " +
-                   "README in a subdirectory.")
+                   "README and a configuration file in a subdirectory.")
+@click.option("-r", "--remote-config-file", default=None, type=click.STRING,
+              help="Name of the configuration file to control howfairis'es behavior. The configuration " +
+                   "file needs to be on the remote, and takes into account the value of " +
+                   "--branch and --path. Default: .howfairis.yml")
 @click.option("-t", "--show-trace", default=None, type=click.Choice(["yes", "no"], case_sensitive=True),
               help="Show full traceback on errors. Default: no")
 @click.option("-v", "--version", default=False, is_flag=True,
               help="Show version and exit.")
 @click.argument("url", required=False)
-def cli(url=None, branch=None, config_file=None, include_comments=None,
-        path=None, show_trace=False, version=False, show_default_config=False):
+def cli(url=None, branch=None, config_file=None, remote_config_file=None, path=None,
+        show_trace=False, version=False, show_default_config=False):
+
     """Determine compliance with recommendations from fair-software.eu for the GitHub or GitLab repository at URL."""
 
     if version is True:
@@ -89,19 +90,26 @@ def cli(url=None, branch=None, config_file=None, include_comments=None,
     init_terminal_colors()
     assert url is not None, "Expected URL to not be emtpy."
     print("Checking compliance with fair-software.eu...")
+
     if url is not None:
         print("url: " + url)
-    if config_file is not None:
-        print("config_file: " + config_file)
+
     if branch is not None:
         print("branch: " + branch)
+
     if path is not None:
         print("path: " + path)
 
-    repo = Repo(url, branch, path)
-    config = Config(repo, config_file, include_comments)
+    if remote_config_file is not None:
+        print("remote_config_file: " + remote_config_file)
 
-    checker = Checker(config)
+    if config_file is not None:
+        print("config_file: " + config_file)
+
+    repo = Repo(url, branch, path, remote_config_file)
+    config = Config(repo, config_file)
+
+    checker = Checker(config, repo)
     checker.check_five_recommendations()
     check_badge(compliance=checker.compliance, readme=checker.readme)
 

--- a/howfairis/cli.py
+++ b/howfairis/cli.py
@@ -55,6 +55,8 @@ def check_badge(compliance, readme=None):
                    "file needs to be present on the local system and can include a relative path.")
 @click.option("-d", "--show-default-config", default=False, is_flag=True,
               help="Show default configuration and exit.")
+@click.option("-i", "--ignore-remote-config", default=False, is_flag=True,
+              help="Ignore any configuration files on the remote.")
 @click.option("-p", "--path", default=None, type=click.STRING,
               help="Relative path (on the remote). Use this if you want howfairis to look for a " +
                    "README and a configuration file in a subdirectory.")
@@ -68,7 +70,7 @@ def check_badge(compliance, readme=None):
               help="Show version and exit.")
 @click.argument("url", required=False)
 def cli(url=None, branch=None, config_file=None, remote_config_file=None, path=None,
-        show_trace=False, version=False, show_default_config=False):
+        show_trace=False, version=False, ignore_remote_config=False, show_default_config=False):
 
     """Determine compliance with recommendations from fair-software.eu for the GitHub or GitLab repository at URL."""
 
@@ -100,14 +102,19 @@ def cli(url=None, branch=None, config_file=None, remote_config_file=None, path=N
     if path is not None:
         print("path: " + path)
 
-    if remote_config_file is not None:
-        print("remote_config_file: " + remote_config_file)
+    if ignore_remote_config is True:
+        print("Ignoring any configuration files on the remote.")
+        assert remote_config_file is None, "When ignoring any configuration files on the remote, you" + \
+                                           " should not set a remote configuration filename."
+    else:
+        if remote_config_file is not None:
+            print("Remote configuration filename: " + remote_config_file)
 
     if config_file is not None:
-        print("config_file: " + config_file)
+        print("Local configuration file: " + config_file)
 
     repo = Repo(url, branch, path, remote_config_file)
-    config = Config(repo, config_file)
+    config = Config(repo, config_file, ignore_remote_config)
 
     checker = Checker(config, repo)
     checker.check_five_recommendations()

--- a/howfairis/cli.py
+++ b/howfairis/cli.py
@@ -71,6 +71,7 @@ def check_badge(compliance, readme=None):
 @click.argument("url", required=False)
 def cli(url=None, branch=None, config_file=None, remote_config_file=None, path=None,
         show_trace=False, version=False, ignore_remote_config=False, show_default_config=False):
+    # pylint: disable=too-many-locals
 
     """Determine compliance with recommendations from fair-software.eu for the GitHub or GitLab repository at URL."""
 

--- a/howfairis/data/.howfairis.yml
+++ b/howfairis/data/.howfairis.yml
@@ -1,7 +1,6 @@
-force:
-  repository: ~
-  license: ~
-  registry: ~
-  citation: ~
-  checklist: ~
+force_repository: ~
+force_license: ~
+force_registry: ~
+force_citation: ~
+force_checklist: ~
 include_comments: false

--- a/howfairis/mixins/ChecklistMixin.py
+++ b/howfairis/mixins/ChecklistMixin.py
@@ -1,10 +1,7 @@
 class ChecklistMixin:
 
     def check_checklist(self):
-        force = self.config.yamldata.get("force", dict())
-        if not isinstance(force, dict):
-            force = dict()
-        force_state = force.get("checklist")
+        force_state = self.config.merged.get("force_checklist")
         if force_state not in [True, False, None]:
             raise ValueError("Unexpected configuration value for force.checklist.")
         if isinstance(force_state, bool):

--- a/howfairis/mixins/CitationMixin.py
+++ b/howfairis/mixins/CitationMixin.py
@@ -4,10 +4,7 @@ import requests
 class CitationMixin:
 
     def check_citation(self):
-        force = self.config.yamldata.get("force", dict())
-        if not isinstance(force, dict):
-            force = dict()
-        force_state = force.get("citation")
+        force_state = self.config.merged.get("force_citation")
         if force_state not in [True, False, None]:
             raise ValueError("Unexpected configuration value for force.citation.")
         if isinstance(force_state, bool):
@@ -24,7 +21,7 @@ class CitationMixin:
         return True in results
 
     def has_citation_file(self):
-        url = self.config.repo.raw_url_format_string.format("CITATION")
+        url = self.repo.raw_url_format_string.format("CITATION")
         try:
             response = requests.get(url)
             # If the response was successful, no Exception will be raised
@@ -36,7 +33,7 @@ class CitationMixin:
         return True
 
     def has_citationcff_file(self):
-        url = self.config.repo.raw_url_format_string.format("CITATION.cff")
+        url = self.repo.raw_url_format_string.format("CITATION.cff")
         try:
             response = requests.get(url)
             # If the response was successful, no Exception will be raised
@@ -48,7 +45,7 @@ class CitationMixin:
         return True
 
     def has_codemeta_file(self):
-        url = self.config.repo.raw_url_format_string.format("codemeta.json")
+        url = self.repo.raw_url_format_string.format("codemeta.json")
         try:
             response = requests.get(url)
             # If the response was successful, no Exception will be raised
@@ -65,7 +62,7 @@ class CitationMixin:
         return self._eval_regexes(regexes)
 
     def has_zenodo_metadata_file(self):
-        url = self.config.repo.raw_url_format_string.format(".zenodo.json")
+        url = self.repo.raw_url_format_string.format(".zenodo.json")
         try:
             response = requests.get(url)
             # If the response was successful, no Exception will be raised

--- a/howfairis/mixins/LicenseMixin.py
+++ b/howfairis/mixins/LicenseMixin.py
@@ -6,10 +6,7 @@ from howfairis.Platform import Platform
 class LicenseMixin:
 
     def check_license(self):
-        force = self.config.yamldata.get("force", dict())
-        if not isinstance(force, dict):
-            force = dict()
-        force_state = force.get("license")
+        force_state = self.config.merged.get("force_license")
         if force_state not in [True, False, None]:
             raise ValueError("Unexpected configuration value for force.license.")
         if isinstance(force_state, bool):
@@ -23,8 +20,8 @@ class LicenseMixin:
 
         r = False
 
-        if self.config.repo.platform == Platform.GITHUB:
-            url = self.config.repo.api + "/license"
+        if self.repo.platform == Platform.GITHUB:
+            url = self.repo.api + "/license"
             try:
                 response = requests.get(url)
                 # If the response was successful, no Exception will be raised
@@ -34,8 +31,8 @@ class LicenseMixin:
                 return r
             r = True
 
-        if self.config.repo.platform == Platform.GITLAB:
-            url = "https://gitlab.com/{0}/{1}".format(self.config.repo.owner, self.config.repo.repo)
+        if self.repo.platform == Platform.GITLAB:
+            url = "https://gitlab.com/{0}/{1}".format(self.repo.owner, self.repo.repo)
 
             try:
                 response = requests.get(url)

--- a/howfairis/mixins/RegistryMixin.py
+++ b/howfairis/mixins/RegistryMixin.py
@@ -5,10 +5,7 @@ from howfairis.Platform import Platform
 class RegistryMixin:
 
     def check_registry(self):
-        force = self.config.yamldata.get("force", dict())
-        if not isinstance(force, dict):
-            force = dict()
-        force_state = force.get("registry")
+        force_state = self.config.merged.get("force_registry", dict())
         if force_state not in [True, False, None]:
             raise ValueError("Unexpected configuration value for force.registry.")
         if isinstance(force_state, bool):
@@ -82,9 +79,9 @@ class RegistryMixin:
 
         r = False
 
-        if self.config.repo.platform == Platform.GITHUB:
+        if self.repo.platform == Platform.GITHUB:
             try:
-                response = requests.get(self.config.repo.url)
+                response = requests.get(self.repo.url)
                 # If the response was successful, no Exception will be raised
                 response.raise_for_status()
             except requests.HTTPError:

--- a/howfairis/mixins/RepositoryMixin.py
+++ b/howfairis/mixins/RepositoryMixin.py
@@ -5,10 +5,7 @@ from howfairis.Platform import Platform
 class RepositoryMixin:
 
     def check_repository(self):
-        force = self.config.yamldata.get("force", dict())
-        if not isinstance(force, dict):
-            force = dict()
-        force_state = force.get("repository")
+        force_state = self.config.merged.get("force_repository")
         if force_state not in [True, False, None]:
             raise ValueError("Unexpected configuration value for force.repository.")
         if isinstance(force_state, bool):
@@ -20,10 +17,10 @@ class RepositoryMixin:
 
     def has_open_repository(self):
 
-        if self.config.repo.platform == Platform.GITHUB:
-            url = self.config.repo.api
-        elif self.config.repo.platform == Platform.GITLAB:
-            url = self.config.repo.api + "/repository/tree"
+        if self.repo.platform == Platform.GITHUB:
+            url = self.repo.api
+        elif self.repo.platform == Platform.GITLAB:
+            url = self.repo.api + "/repository/tree"
 
         try:
             response = requests.get(url)

--- a/howfairis/schema.py
+++ b/howfairis/schema.py
@@ -4,13 +4,11 @@ from voluptuous import Schema
 
 
 schema = {
-    Optional("force"): Any({
-        Optional("repository"): Any(bool, None),
-        Optional("license"): Any(bool, None),
-        Optional("registry"): Any(bool, None),
-        Optional("citation"): Any(bool, None),
-        Optional("checklist"): Any(bool, None),
-    }, None),
+    Optional("force_repository"): Any(bool, None),
+    Optional("force_license"): Any(bool, None),
+    Optional("force_registry"): Any(bool, None),
+    Optional("force_citation"): Any(bool, None),
+    Optional("force_checklist"): Any(bool, None),
     Optional("include_comments"): Any(bool, None)
 }
 

--- a/livetests/test_howfairis.py
+++ b/livetests/test_howfairis.py
@@ -36,4 +36,4 @@ def test_heavy_handed_livetest_rsd():
             assert isinstance(c, bool)
 
         # sleep to avoid rate limiting of GitHub API
-        time.sleep(10)
+        time.sleep(20)

--- a/livetests/test_howfairis.py
+++ b/livetests/test_howfairis.py
@@ -31,7 +31,7 @@ def test_heavy_handed_livetest_rsd():
         print(url)
         repo = Repo(url)
         config = Config(repo)
-        checker = Checker(config).check_five_recommendations()
+        checker = Checker(config, repo).check_five_recommendations()
         for c in checker.compliance:
             assert isinstance(c, bool)
 


### PR DESCRIPTION
This PR simplifies the config file schema. It adds a loader that subsequently looks for 

1. config files in the package itself
1. in the repo that is being evaluated
1. in a file that the user points to

these are then combined to yield the effective configuration.

Additionally, this PR adds a CLI option to ignore any configuration files that may exist on the remote. This was possible before, but required the user to first make a local file
```shell
howfairis -d > .howfairis.yml
```
and then 

```shell
howfairis -c .howfairis.yml <repo>
```

With this PR, you can just do
```shell
howfairis -i <repo>
```
