### PR TITLE
relaxed anaconda.org regexp

### DIFF
--- a/howfairis/mixins/RegistryMixin.py
+++ b/howfairis/mixins/RegistryMixin.py
@@ -36,7 +36,7 @@ class RegistryMixin:
         return self._eval_regexes(regexes)
 
     def has_conda_badge(self):
-        regexes = [r"https://anaconda\.org/.*/.*/badges/installer/conda\.svg",
+        regexes = [r"https://anaconda\.org/.*",
                    r"https://img\.shields\.io/conda/.*"]
         return self._eval_regexes(regexes)
 


### PR DESCRIPTION
Refs #68

## Describe the changes made in this pull request

Relaxed regexp matching anaconda.org badges on README.md pages to make it more permissive to accepting conda badges

## Instructions to review the pull request

1. Rebuild howfairis
1. Running `howfairis https://github.com/xtensor-stack/xtensor-fftw` should now result in `✓ has_conda_badge` (before change it reported `× has_conda_badge`)