### PR TITLE
Name of default_branch is now retrieved from respective platform

### DIFF
--- a/howfairis/Repo.py
+++ b/howfairis/Repo.py
@@ -58,14 +58,20 @@ class Repo:
         return None
 
     def _construct_urls(self):
+        if self.branch is not None:
+            # User specified a branch, use that regardless of whether it actually exists
+            branch = self.branch
+        else:
+            branch = self.default_branch
+
         if self.platform == Platform.GITHUB:
             api = "https://api.github.com/repos/{0}/{1}".format(self.owner, self.repo)
             raw_url_format_string = "https://raw.githubusercontent.com/{0}/{1}/{2}{3}" \
-                                    .format(self.owner, self.repo, self.branch, self.path) + "/{0}"
+                                    .format(self.owner, self.repo, branch, self.path) + "/{0}"
 
         elif self.platform == Platform.GITLAB:
             api = "https://gitlab.com/api/v4/projects/{0}%2F{1}".format(self.owner, self.repo)
             raw_url_format_string = "https://gitlab.com/{0}/{1}/-/raw/{2}{3}" \
-                                    .format(self.owner, self.repo, self.branch, self.path) + "/{0}"
+                                    .format(self.owner, self.repo, branch, self.path) + "/{0}"
 
         return api, raw_url_format_string

--- a/howfairis/Repo.py
+++ b/howfairis/Repo.py
@@ -1,5 +1,5 @@
-from .Platform import Platform
 import requests
+from .Platform import Platform
 
 
 class Repo:

--- a/howfairis/Repo.py
+++ b/howfairis/Repo.py
@@ -3,45 +3,69 @@ from .Platform import Platform
 
 class Repo:
     def __init__(self, url, branch=None, path=None, config_file=None):
-        self.api = None
-        self.branch = "master" if branch is None else branch
-        self.config_file = config_file
-        self.owner = None
-        self.path = "" if path is None else "/" + path.strip("/")
-        self.platform = None
-        self.raw_url_format_string = None
-        self.repo = None
+        # run assertions on user input
+        Repo._check_assertions(url)
+
+        # assign arguments to instance members
         self.url = url
+        self.branch = branch
+        self.path = "" if path is None else "/" + path.strip("/")
+        self.config_file = config_file
 
-        self._deconstruct_url()
+        # assign remaining members as needed
+        self.platform = self._derive_platform()
+        self.default_branch = self._set_default_branch()
+        self.owner, self.repo = self._derive_owner_and_repo()
 
-    def _deconstruct_url(self):
+        # construct raw_url and api url
+        self.api, self.raw_url_format_string = self._construct_urls()
 
-        assert self.url.startswith("https://"), "url should start with https://"
-        assert True in [self.url.startswith("https://github.com"),
-                        self.url.startswith("https://gitlab.com")], "Repository should be on GitHub or on GitLab."
+    def _check_assertions(url):
+        assert url.startswith("https://"), "url should start with https://"
+        assert True in [url.startswith("https://github.com"),
+                        url.startswith("https://gitlab.com")], "Repository should be on github.com or on gitlab.com."
 
-        if self.url.startswith("https://github.com"):
-            self.platform = Platform.GITHUB
+    def _derive_owner_and_repo(self):
+        if self.platform == Platform.GITHUB:
             try:
-                self.owner, self.repo = self.url.replace("https://github.com", "").strip("/").split("/")[:2]
+                owner, repo = self.url.replace("https://github.com", "").strip("/").split("/")[:2]
             except ValueError as e:
                 raise ValueError("Bad value for input argument URL.") from e
-            self.raw_url_format_string = "https://raw.githubusercontent.com/{0}/{1}/{2}{3}" \
-                                         .format(self.owner, self.repo, self.branch, self.path) + "/{0}"
-            self.api = "https://api.github.com/repos/{0}/{1}".format(self.owner, self.repo)
 
-        elif self.url.startswith("https://gitlab.com"):
-            self.platform = Platform.GITLAB
+        elif self.platform == Platform.GITLAB:
             try:
-                self.owner, self.repo = self.url.replace("https://gitlab.com", "").strip("/").split("/")[:2]
+                owner, repo = self.url.replace("https://gitlab.com", "").strip("/").split("/")[:2]
             except ValueError as e:
                 raise ValueError("Bad value for input argument URL.") from e
-            self.raw_url_format_string = "https://gitlab.com/{0}/{1}/-/raw/{2}{3}" \
-                                         .format(self.owner, self.repo, self.branch, self.path) + "/{0}"
-            self.api = "https://gitlab.com/api/v4/projects/{0}%2F{1}".format(self.owner, self.repo)
 
-        if self.owner == "" or self.repo == "":
+        if owner == "" or repo == "":
             raise ValueError("Bad value for input argument URL.")
 
-        return self
+        return owner, repo
+
+    def _set_default_branch(self):
+        if self.platform == Platform.GITHUB:
+            return "master"
+        if self.platform == Platform.GITLAB:
+            return "master"
+        return None
+
+    def _derive_platform(self):
+        if self.url.startswith("https://github.com"):
+            return Platform.GITHUB
+        if self.url.startswith("https://gitlab.com"):
+            return Platform.GITLAB
+        return None
+
+    def _construct_urls(self):
+        if self.platform == Platform.GITHUB:
+            api = "https://api.github.com/repos/{0}/{1}".format(self.owner, self.repo)
+            raw_url_format_string = "https://raw.githubusercontent.com/{0}/{1}/{2}{3}" \
+                                    .format(self.owner, self.repo, self.branch, self.path) + "/{0}"
+
+        elif self.platform == Platform.GITLAB:
+            api = "https://gitlab.com/api/v4/projects/{0}%2F{1}".format(self.owner, self.repo)
+            raw_url_format_string = "https://gitlab.com/{0}/{1}/-/raw/{2}{3}" \
+                                    .format(self.owner, self.repo, self.branch, self.path) + "/{0}"
+
+        return api, raw_url_format_string

--- a/howfairis/Repo.py
+++ b/howfairis/Repo.py
@@ -20,6 +20,7 @@ class Repo:
         # construct raw_url and api url
         self.api, self.raw_url_format_string = self._construct_urls()
 
+    @staticmethod
     def _check_assertions(url):
         assert url.startswith("https://"), "url should start with https://"
         assert True in [url.startswith("https://github.com"),

--- a/howfairis/Repo.py
+++ b/howfairis/Repo.py
@@ -17,7 +17,7 @@ class Repo:
         self.platform = self._derive_platform()
         self.owner, self.repo = self._derive_owner_and_repo()
         self.api = self._derive_api()
-        self.default_branch = self._set_default_branch()
+        self.default_branch = self._get_default_branch()
         self.raw_url_format_string = self._derive_raw_url_format_string()
 
     @staticmethod
@@ -44,7 +44,7 @@ class Repo:
 
         return owner, repo
 
-    def _set_default_branch(self):
+    def _get_default_branch(self):
         # GitHub API and GitLab API work the same
         response = requests.get(self.api)
         # If the response was successful, the next line will not raise any Exception

--- a/howfairis/Repo.py
+++ b/howfairis/Repo.py
@@ -26,6 +26,14 @@ class Repo:
         assert True in [url.startswith("https://github.com"),
                         url.startswith("https://gitlab.com")], "Repository should be on github.com or on gitlab.com."
 
+    def _derive_api(self):
+        if self.platform == Platform.GITHUB:
+            api = "https://api.github.com/repos/{0}/{1}".format(self.owner, self.repo)
+        elif self.platform == Platform.GITLAB:
+            api = "https://gitlab.com/api/v4/projects/{0}%2F{1}".format(self.owner, self.repo)
+
+        return api
+
     def _derive_owner_and_repo(self):
         if self.platform == Platform.GITHUB:
             try:
@@ -44,27 +52,14 @@ class Repo:
 
         return owner, repo
 
-    def _get_default_branch(self):
-        # GitHub API and GitLab API work the same
-        response = requests.get(self.api)
-        # If the response was successful, the next line will not raise any Exception
-        response.raise_for_status()
-        return response.json().get("default_branch", None)
-
     def _derive_platform(self):
         if self.url.startswith("https://github.com"):
             return Platform.GITHUB
+
         if self.url.startswith("https://gitlab.com"):
             return Platform.GITLAB
+
         return None
-
-    def _derive_api(self):
-        if self.platform == Platform.GITHUB:
-            api = "https://api.github.com/repos/{0}/{1}".format(self.owner, self.repo)
-        elif self.platform == Platform.GITLAB:
-            api = "https://gitlab.com/api/v4/projects/{0}%2F{1}".format(self.owner, self.repo)
-
-        return api
 
     def _derive_raw_url_format_string(self):
         if self.branch is not None:
@@ -82,3 +77,11 @@ class Repo:
                                     .format(self.owner, self.repo, branch, self.path) + "/{0}"
 
         return raw_url_format_string
+
+    def _get_default_branch(self):
+        # GitHub API and GitLab API work the same
+        response = requests.get(self.api)
+
+        # If the request was successful, the next line will not raise any Exception
+        response.raise_for_status()
+        return response.json().get("default_branch", None)

--- a/howfairis/cli.py
+++ b/howfairis/cli.py
@@ -2,10 +2,10 @@ import os
 import sys
 import click
 from colorama import init as init_terminal_colors
-from howfairis import __version__
 from howfairis import Checker
 from howfairis import Config
 from howfairis import Repo
+from howfairis import __version__
 
 
 # pylint: disable=too-many-arguments

--- a/howfairis/cli.py
+++ b/howfairis/cli.py
@@ -2,10 +2,10 @@ import os
 import sys
 import click
 from colorama import init as init_terminal_colors
-from howfairis import Checker
 from howfairis import __version__
-from howfairis.Config import Config
-from howfairis.Repo import Repo
+from howfairis import Checker
+from howfairis import Config
+from howfairis import Repo
 
 
 # pylint: disable=too-many-arguments


### PR DESCRIPTION
In this PR, I split `Repo._construct_urls` method into multiple, smaller private methods that each do one thing, and I added retrieval of the `default_branch` string using the APIs for the respective platforms. 

Refs #48

