### PR TITLE
added badge context checks

### DIFF
--- a/howfairis/Checker.py
+++ b/howfairis/Checker.py
@@ -99,25 +99,22 @@ class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, Check
         return self
 
     def has_open_brackets(self, badges):
-        if len(badges) == 0: 
+        if len(badges) == 0:
             return(False)
         else:
             last_badge = badges[-1]
             open_brackets = 0
             closing_brackets = 0
-            for i in range(0, len(last_badge)):
-                if last_badge[i] == "[":
+            for i, c in enumerate(last_badge):
+                if c == "[":
                     open_brackets += 1
-                if last_badge[i] == "]":
+                if c == "]":
                     closing_brackets += 1
-            if (open_brackets > closing_brackets or 
-                open_brackets == 0 and closing_brackets == 0):
-                return(True)
-            else:
-                return(False)
+            return(open_brackets > closing_brackets or
+                   (open_brackets == 0 and closing_brackets == 0))
 
     def finishes_with_image_tag(self, badges):
-        return(len(badges) > 0 and re.search("image::$", badges[-1])) 
+        return(len(badges) > 0 and re.search("image::$", badges[-1]))
 
     def get_badges_rst(self):
         badges = []
@@ -129,7 +126,7 @@ class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, Check
     def get_badges_md(self):
         badges = []
         for text_part in self.readme.text.split():
-            if re.search("!\[", text_part) or self.has_open_brackets(badges):
+            if re.search('![[]', text_part) or self.has_open_brackets(badges):
                 badges.append(text_part)
         return("\n".join(badges))
 
@@ -138,15 +135,14 @@ class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, Check
             return False
         if self.readme.fmt == ReadmeFormat.MARKDOWN:
             return(self.get_badges_md())
-        elif self.readme.fmt == ReadmeFormat.RESTRUCTUREDTEXT:
+        if self.readme.fmt == ReadmeFormat.RESTRUCTUREDTEXT:
             return(self.get_badges_rst())
-        else:
-            return(self)
+        return(self)
 
     def check_five_recommendations(self):
         badges = Checker(self.config, self.repo)
-        badges.readme = Readme(filename=self.readme.filename, 
-                               text=self.get_badges(), 
+        badges.readme = Readme(filename=self.readme.filename,
+                               text=self.get_badges(),
                                fmt=self.readme.fmt)
         self.compliance = Compliance(repository=badges.check_repository(),
                                      license_=badges.check_license(),

--- a/howfairis/Checker.py
+++ b/howfairis/Checker.py
@@ -101,17 +101,13 @@ class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, Check
     def has_open_brackets(self, badges):
         if len(badges) == 0:
             return(False)
-        else:
-            last_badge = badges[-1]
-            open_brackets = 0
-            closing_brackets = 0
-            for i, c in enumerate(last_badge):
-                if c == "[":
-                    open_brackets += 1
-                if c == "]":
-                    closing_brackets += 1
-            return(open_brackets > closing_brackets or
-                   (open_brackets == 0 and closing_brackets == 0))
+        last_badge = badges[-1]
+        bracket_counts = { "[":0, "]":0 } 
+        for i, c in enumerate(last_badge):
+            if last_badge[i] == "[" or last_badge[i] == "]":
+                bracket_counts[c] += 1
+        return(bracket_counts["["] > bracket_counts["]"] or
+               (bracket_counts["["] == 0 and bracket_counts["]"] == 0))
 
     def finishes_with_image_tag(self, badges):
         return(len(badges) > 0 and re.search("image::$", badges[-1]))

--- a/howfairis/Checker.py
+++ b/howfairis/Checker.py
@@ -98,11 +98,60 @@ class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, Check
 
         return self
 
+    def has_open_brackets(self, badges):
+        if len(badges) == 0: 
+            return(False)
+        else:
+            last_badge = badges[-1]
+            open_brackets = 0
+            closing_brackets = 0
+            for i in range(0, len(last_badge)):
+                if last_badge[i] == "[":
+                    open_brackets += 1
+                if last_badge[i] == "]":
+                    closing_brackets += 1
+            if (open_brackets > closing_brackets or 
+                open_brackets == 0 and closing_brackets == 0):
+                return(True)
+            else:
+                return(False)
+
+    def finishes_with_image_tag(self, badges):
+        return(len(badges) > 0 and re.search("image::$", badges[-1])) 
+
+    def get_badges_rst(self):
+        badges = []
+        for text_part in self.readme.text.split():
+            if re.search("image::", text_part) or self.finishes_with_image_tag(badges):
+                badges.append(text_part)
+        return("\n".join(badges))
+
+    def get_badges_md(self):
+        badges = []
+        for text_part in self.readme.text.split():
+            if re.search("!\[", text_part) or self.has_open_brackets(badges):
+                badges.append(text_part)
+        return("\n".join(badges))
+
+    def get_badges(self):
+        if self.readme.text is None:
+            return False
+        if self.readme.fmt == ReadmeFormat.MARKDOWN:
+            return(self.get_badges_md())
+        elif self.readme.fmt == ReadmeFormat.RESTRUCTUREDTEXT:
+            return(self.get_badges_rst())
+        else:
+            return(self)
+
     def check_five_recommendations(self):
-        self.compliance = Compliance(repository=self.check_repository(),
-                                     license_=self.check_license(),
-                                     registry=self.check_registry(),
-                                     citation=self.check_citation(),
-                                     checklist=self.check_checklist())
+        badges = Checker(self.config, self.repo)
+        badges.readme = Readme(filename=self.readme.filename, 
+                               text=self.get_badges(), 
+                               fmt=self.readme.fmt)
+        self.compliance = Compliance(repository=badges.check_repository(),
+                                     license_=badges.check_license(),
+                                     registry=badges.check_registry(),
+                                     citation=badges.check_citation(),
+                                     checklist=badges.check_checklist())
         self._calc_badge()
         return self

--- a/howfairis/Checker.py
+++ b/howfairis/Checker.py
@@ -102,7 +102,7 @@ class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, Check
         if len(badges) == 0:
             return(False)
         last_badge = badges[-1]
-        bracket_counts = { "[":0, "]":0 } 
+        bracket_counts = {"[": 0, "]": 0}
         for i, c in enumerate(last_badge):
             if last_badge[i] == "[" or last_badge[i] == "]":
                 bracket_counts[c] += 1


### PR DESCRIPTION
Refs #96 

## Describe the changes made in this pull request

Added checks for badges (links to images) before checking for badge urls with regexps. These new checks get rid of many false positives.

## Instructions to review the pull request

1. Rebuild howfairis
2. Running `howfairis https://github.com/xtensor-stack/xtensor-fftw` should result in `✓ has_conda_badge`
3. Running `howfairis https://github.com/bsipos/bsipos-conda` should result in `× has_conda_badge`. Before this PR it reported `✓ has_conda_badge` (false positive)
4. Running `howfairis https://github.com/pygame/pygame` should result in compliance score: `xoxoo` (test for .rst file type)