### PR TITLE
now recognizes various conda badges

### DIFF
--- a/howfairis/mixins/RegistryMixin.py
+++ b/howfairis/mixins/RegistryMixin.py
@@ -36,7 +36,9 @@ class RegistryMixin:
         return self._eval_regexes(regexes)
 
     def has_conda_badge(self):
-        regexes = [r"https://anaconda\.org/.*",
+        regexes = [r"https://anaconda\.org/.*/.*/badges/downloads\.svg",
+                   r"https://anaconda\.org/.*/.*/badges/installer/conda\.svg",
+                   r"https://anaconda\.org/.*/.*/badges/version\.svg",
                    r"https://img\.shields\.io/conda/.*"]
         return self._eval_regexes(regexes)
 


### PR DESCRIPTION
With this PR, I'm now getting correct results for 

- `howfairis https://github.com/xtensor-stack/xtensor-fftw` (previously unrecognized badge link to conda; refs #68)
- `howfairis https://github.com/bsipos/bsipos-conda` (text has anaconda link that isnt a badge)
- `howfairis https://github.com/pygame/pygame` (restructured text)
