### PR TITLE
branch cli argument also accepts tag and sha

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,7 +143,9 @@ Which then shows something like:
       GitHub or GitLab repository at URL.
 
     Options:
-      -b, --branch TEXT              Which git branch to use.
+      -b, --branch TEXT              Which git branch to use. Also accepts other
+                                     git references like SHA or tag.
+
       -c, --config-file PATH         Name of the configuration file to control
                                      howfairis'es behavior. The configuration file
                                      needs to be present on the local system and

--- a/howfairis/cli.py
+++ b/howfairis/cli.py
@@ -11,7 +11,7 @@ from howfairis.Repo import Repo
 # pylint: disable=too-many-arguments
 @click.command(context_settings=dict(help_option_names=["-h", "--help"]))
 @click.option("-b", "--branch", default=None, type=click.STRING,
-              help="Which git branch to use.")
+              help="Which git branch to use. Also accepts other git references like SHA or tag.")
 @click.option("-c", "--config-file", default=None, type=click.Path(),
               help="Name of the configuration file to control howfairis'es behavior. The configuration " +
                    "file needs to be present on the local system and can include a relative path.")


### PR DESCRIPTION
left the `--branch` argument as-is, but documented that sha and tag can also be used; refs #95