### PR TITLE
Updated README with Python versions badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,16 +11,24 @@ fair-software.eu_ recommendations.
 Badges
 ------
 
-====================================================== ==========================
+
+====================================================== ===========================
 fair-software.nl recommendations
-====================================================== ==========================
-1/5 code repository                                    |github repo badge|
-2/5 license                                            |github license badge|
-3/5 community registry                                 |pypi badge|
-4/5 citation                                           |zenodo badge|
-5/5 checklist
+====================================================== ===========================
+(1/5) code repository                                  |github repo badge|
+(2/5) license                                          |github license badge|
+(3/5) community registry                               |pypi badge|
+(4/5) citation                                         |zenodo badge|
+(5/5) checklist
 overall                                                |fair-software badge|
-====================================================== ==========================
+**Other best practices**
+Documentation                                          |ReadTheDocs Badge|
+Supported Python versions                              |python versions badge| 
+**GitHub Actions**
+Citation metadata consistency                          |workflow cffconvert badge|
+Unit tests                                             |workflow tests badge|
+Live tests (triggered manually)                        |workflow livetests badge|
+====================================================== ===========================
 
 .. |github repo badge| image:: https://img.shields.io/badge/github-repo-000.svg?logo=github&labelColor=gray&color=blue
    :target: https://github.com/fair-software/howfairis
@@ -37,27 +45,12 @@ overall                                                |fair-software badge|
 .. |fair-software badge| image:: https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8B-yellow
    :target: https://fair-software.eu
 
-====================================================== ==========================
-Other best practices
-====================================================== ==========================
-Documentation                                          |ReadTheDocs Badge|
-Supported Python versions                              |python versions badge| 
-====================================================== ==========================
-
 .. |ReadTheDocs Badge| image:: https://readthedocs.org/projects/howfairis/badge/?version=latest
    :target: https://howfairis.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
    
 .. |python versions badge| image:: https://img.shields.io/pypi/pyversions/howfairis.svg
    :target: https://pypi.python.org/pypi/howfairis   
-
-====================================================== ===========================
-GitHub Actions
-====================================================== ===========================
-Citation metadata consistency                          |workflow cffconvert badge|
-Unit tests                                             |workflow tests badge|
-Live tests (triggered manually)                        |workflow livetests badge|
-====================================================== ===========================
 
 .. |workflow tests badge| image:: https://github.com/fair-software/howfairis/workflows/tests/badge.svg
    :target: https://github.com/fair-software/howfairis/actions?query=workflow%3Atests

--- a/README.rst
+++ b/README.rst
@@ -38,14 +38,18 @@ overall                                                |fair-software badge|
    :target: https://fair-software.eu
 
 ====================================================== ==========================
-Code quality checks
+Other best practices
 ====================================================== ==========================
 Documentation                                          |ReadTheDocs Badge|
+Supported Python versions                              |python versions badge| 
 ====================================================== ==========================
 
 .. |ReadTheDocs Badge| image:: https://readthedocs.org/projects/howfairis/badge/?version=latest
    :target: https://howfairis.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
+   
+.. |python versions badge| image:: https://img.shields.io/pypi/pyversions/howfairis.svg
+   :target: https://pypi.python.org/pypi/howfairis   
 
 ====================================================== ===========================
 GitHub Actions


### PR DESCRIPTION
This PR adds a badge to the README that shows which python versions are supported. The necessary data is coming from pypi's metadata, which in turn comes from our `setup.py`