### PR TITLE
Checker's readme assignment not none

### DIFF
--- a/howfairis/checker.py
+++ b/howfairis/checker.py
@@ -37,10 +37,8 @@ class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, Check
         super().__init__()
         self.compliance = None
         self.config = config
-        self.readme = None
         self.repo = repo
-
-        self._get_readme()
+        self.readme = self._get_readme()
 
     def _eval_regexes(self, regexes, check_name=None):
         if check_name is None:
@@ -80,14 +78,12 @@ class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, Check
                 text = response.text
             else:
                 text = remove_comments(response.text)
-            self.readme = Readme(filename=readme_filename,
-                                 text=text, fmt=readme_fmt)
-            return self
 
-        print("Did not find a README[.md|.rst] file at " +
-              raw_url.replace(readme_filename, ""))
-        self.readme = Readme(filename=None, text=None, fmt=None)
-        return self
+            return Readme(filename=readme_filename, text=text, fmt=readme_fmt)
+
+        print("Did not find a README[.md|.rst] file at " + raw_url.replace(readme_filename, ""))
+
+        return Readme(filename=None, text=None, fmt=None)
 
     @staticmethod
     def _print_state(check_name="", state=None, indent=6):

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -28,14 +28,14 @@ def badghurl_checker(requests_mock: Mocker):
 
 
 def test_checker_badghurl_emptyreadme(badghurl_checker: Checker):
-    readme = badghurl_checker.readme
+    actual_readme = badghurl_checker.readme
 
-    expected = Readme(filename=None, text=None, fmt=None)
-    assert readme == expected
+    expected_readme = Readme(filename=None, text=None, fmt=None)
+    assert actual_readme == expected_readme
 
 
 def test_checker_check_five_recommendations(badghurl_checker: Checker):
-    compliance = badghurl_checker.check_five_recommendations()
+    actual_compliance = badghurl_checker.check_five_recommendations()
 
-    expected = Compliance(repository=False, license_=False, registry=False, citation=False, checklist=False)
-    assert compliance == expected
+    expected_compliance = Compliance(repository=False, license_=False, registry=False, citation=False, checklist=False)
+    assert actual_compliance == expected_compliance


### PR DESCRIPTION
refs #176

- checker constructor now directly assigns to `self.readme`
- checker method `_get_readme` now returns instance of `Readme` instead of instance of `Checker` with changes
- updated tests
