### PR TITLE
Updated comparator methods on Compliance

### DIFF
--- a/howfairis/cli.py
+++ b/howfairis/cli.py
@@ -100,7 +100,7 @@ def cli(url=None, branch=None, config_file=None, remote_config_file=None, path=N
         print("Expected badge is equal to the actual badge. It's all good.\n")
         sys.exit(0)
 
-    if current_compliance > previous_compliance:
+    if current_compliance.count() > previous_compliance.count():
         print("Congratulations! The compliance of your repository exceeds " +
               "the current fair-software.eu badge in your " +
               "{0}. You can replace it with the following snippet:\n\n{1}"

--- a/howfairis/compliance.py
+++ b/howfairis/compliance.py
@@ -28,19 +28,7 @@ class Compliance:
         self.repository = repository
 
     def __eq__(self, other):
-        return self.count(True) == other.count(True)
-
-    def __ge__(self, other):
-        return self.count(True) >= other.count(True)
-
-    def __gt__(self, other):
-        return self.count(True) > other.count(True)
-
-    def __le__(self, other):
-        return self.count(True) <= other.count(True)
-
-    def __ne__(self, other):
-        return self.count(True) != other.count(True)
+        return [s is o for s, o in zip(self._state, other._state)] == [True] * 5
 
     def __iter__(self):
         return self
@@ -92,7 +80,7 @@ class Compliance:
 
         return None
 
-    def count(self, value):
+    def count(self, value=True):
         return self._state.count(value)
 
     def urlencode(self, separator="%20%20"):

--- a/howfairis/compliance.py
+++ b/howfairis/compliance.py
@@ -28,7 +28,7 @@ class Compliance:
         self.repository = repository
 
     def __eq__(self, other):
-        return [s is o for s, o in zip(self._state, other._state)] == [True] * 5
+        return isinstance(other, Compliance) and [s is o for s, o in zip(self._state, other._state)] == [True] * 5
 
     def __iter__(self):
         return self


### PR DESCRIPTION
**List of related issues or pull requests**

Refs: #163

**Describe the changes made in this pull request**

- removed all comparators for `Compliance` objects except `__eq__`;
- added a default value of `True` to `Compliance.count()`

**Instructions to review the pull request**

e.g.: make two `Compliance` objects, compare them. Make sure to have two objects with the same count, but different state to see the difference.

```shell
$ python
Python 3.6.9 (default, Oct  8 2020, 12:12:24) 
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from howfairis import Compliance
>>> a = Compliance(True, True, True, False, False)
>>> b = Compliance(True, True, True, False, False)
>>> a == b
True
>>> a > b
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: '>' not supported between instances of 'Compliance' and 'Compliance'
>>> a.count() > b.count()
False
>>> a.count() == b.count()
True
>>> c = Compliance(False, False, True, True, True)
>>> a == c
False
>>> a.count() == c.count()
True
>>> 

```
