### PR TITLE
More precise varnames config

### DIFF
--- a/howfairis/config.py
+++ b/howfairis/config.py
@@ -16,17 +16,17 @@ class Config:
         ignore_remote_config: If true then does not try to merge config from remote repository.
     """
 
-    def __init__(self, repo: Repo, config_filename=None, ignore_remote_config=False):
-        self._default = Config._load_default_config()
-        self._repo = Config._load_repo_config(repo, ignore_remote_config)
-        self._user = Config._load_user_config(config_filename)
-        self._merged = self._merge_configurations()
+    def __init__(self, repo: Repo, user_config_filename=None, ignore_repo_config=False):
+        self._default_config = Config._load_default_config()
+        self._repo_config = Config._load_repo_config(repo, ignore_repo_config)
+        self._user_config = Config._load_user_config(user_config_filename)
+        self._merged_config = self._merge_configurations()
 
     @staticmethod
     def _load_default_config():
         pkg_root = os.path.dirname(__file__)
-        config_filename = os.path.join(pkg_root, "data", ".howfairis.yml")
-        with open(config_filename, "rt") as f:
+        default_config_filename = os.path.join(pkg_root, "data", ".howfairis.yml")
+        with open(default_config_filename, "rt") as f:
             text = f.read()
         default_config = YAML(typ="safe").load(text)
         if default_config is None:
@@ -34,8 +34,7 @@ class Config:
         try:
             validate_against_schema(default_config)
         except (Invalid, MultipleInvalid):
-            print(
-                "Default configuration file should follow the schema for it to be considered.")
+            print("Default configuration file should follow the schema for it to be considered.")
             return dict()
         return default_config
 
@@ -47,47 +46,42 @@ class Config:
         if ignore_remote_config is True:
             return dict()
 
-        if repo.config_file is None:
-            config_filename = ".howfairis.yml"
+        if repo.repo_config_filename is None:
+            raw_url = repo.raw_url_format_string.format(".howfairis.yml")
         else:
-            config_filename = repo.config_file
+            raw_url = repo.raw_url_format_string.format(repo.repo_config_filename)
 
-        raw_url = repo.raw_url_format_string.format(config_filename)
         try:
             response = requests.get(raw_url)
             # If the response was successful, no Exception will be raised
             response.raise_for_status()
             print("Using the configuration file {0}".format(raw_url))
         except requests.HTTPError as e:
-            if repo.config_file is not None:
-                raise Exception(
-                    "Could not find the configuration file {0}".format(raw_url)) from e
+            if repo.repo_config_filename is not None:
+                raise Exception("Could not find the configuration file {0}".format(raw_url)) from e
             return dict()
 
         try:
             repo_config = YAML(typ="safe").load(response.text)
         except Exception as e:
-            raise Exception(
-                "Problem loading YAML configuration from file {0}".format(raw_url)) from e
+            raise Exception("Problem loading YAML configuration from file {0}".format(raw_url)) from e
 
         try:
             validate_against_schema(repo_config)
         except (Invalid, MultipleInvalid):
-            print(
-                "Repository's configuration file should follow the schema for it to be considered.")
+            print("Repository's configuration file should follow the schema for it to be considered.")
             return dict()
 
         return repo_config
 
     @staticmethod
-    def _load_user_config(config_filename):
-        if config_filename is None:
+    def _load_user_config(user_config_filename):
+        if user_config_filename is None:
             return dict()
 
-        p = os.path.join(os.getcwd(), config_filename)
+        p = os.path.join(os.getcwd(), user_config_filename)
         if not os.path.exists(p):
-            raise FileNotFoundError(
-                "{0} doesn't exist.".format(config_filename))
+            raise FileNotFoundError("{0} doesn't exist.".format(user_config_filename))
 
         with open(p, "rt") as f:
             text = f.read()
@@ -97,8 +91,7 @@ class Config:
         try:
             validate_against_schema(user_config)
         except Exception as e:
-            raise Exception(
-                "User configuration file should follow the schema.") from e
+            raise Exception("User configuration file should follow the schema.") from e
         return user_config
 
     def _merge_configurations(self):
@@ -109,31 +102,31 @@ class Config:
             * config from local user
         """
         m = dict()
-        m.update(self._default)
-        m.update(self._repo)
-        m.update(self._user)
+        m.update(self._default_config)
+        m.update(self._repo_config)
+        m.update(self._user_config)
         return m
 
     @property
     def force_repository(self):
-        return self._merged.get("force_repository")
+        return self._merged_config.get("force_repository")
 
     @property
     def force_license(self):
-        return self._merged.get("force_license")
+        return self._merged_config.get("force_license")
 
     @property
     def force_registry(self):
-        return self._merged.get("force_registry")
+        return self._merged_config.get("force_registry")
 
     @property
     def force_citation(self):
-        return self._merged.get("force_citation")
+        return self._merged_config.get("force_citation")
 
     @property
     def force_checklist(self):
-        return self._merged.get("force_checklist")
+        return self._merged_config.get("force_checklist")
 
     @property
     def include_comments(self):
-        return self._merged.get("include_comments")
+        return self._merged_config.get("include_comments")

--- a/howfairis/repo.py
+++ b/howfairis/repo.py
@@ -14,7 +14,7 @@ class Repo:
         config_file: Name of the configuration file to control the behavior of the howfairis package.
 
     """
-    def __init__(self, url: str, branch=None, path=None, config_file=None):
+    def __init__(self, url: str, branch=None, path=None, repo_config_filename=None):
         # run assertions on user input
         Repo._check_assertions(url)
 
@@ -22,7 +22,7 @@ class Repo:
         self.url = url
         self.branch = branch
         self.path = "" if path is None else "/" + path.strip("/")
-        self.config_file = config_file
+        self.repo_config_filename = repo_config_filename
 
         # assign remaining members as needed
         self.platform = self._derive_platform()

--- a/tests/contracts/repo.py
+++ b/tests/contracts/repo.py
@@ -12,10 +12,6 @@ class Contract(ABC):
         pass
 
     @abstractmethod
-    def test_config_file(self, mocked_repo):
-        pass
-
-    @abstractmethod
     def test_default_branch(self, mocked_repo):
         pass
 
@@ -37,6 +33,10 @@ class Contract(ABC):
 
     @abstractmethod
     def test_repo(self, mocked_repo):
+        pass
+
+    @abstractmethod
+    def test_repo_config_filename(self, mocked_repo):
         pass
 
     @abstractmethod

--- a/tests/github/fair_software/badge/test_repo_no_args.py
+++ b/tests/github/fair_software/badge/test_repo_no_args.py
@@ -19,9 +19,6 @@ class TestRepoNoArgs(Contract):
     def test_branch(self, mocked_repo):
         assert mocked_repo.branch is None
 
-    def test_config_file(self, mocked_repo):
-        assert mocked_repo.config_file is None
-
     def test_default_branch(self, mocked_repo):
         assert mocked_repo.default_branch == "master"
 
@@ -40,6 +37,9 @@ class TestRepoNoArgs(Contract):
 
     def test_repo(self, mocked_repo):
         assert mocked_repo.repo == "badge"
+
+    def test_repo_config_filename(self, mocked_repo):
+        assert mocked_repo.repo_config_filename is None
 
     def test_url(self, mocked_repo):
         assert mocked_repo.url == "https://github.com/fair-software/badge"

--- a/tests/github/fair_software/badge/test_repo_with_branch_develop.py
+++ b/tests/github/fair_software/badge/test_repo_with_branch_develop.py
@@ -19,9 +19,6 @@ class TestRepoWithBranchDevelop(Contract):
     def test_branch(self, mocked_repo):
         assert mocked_repo.branch == "develop"
 
-    def test_config_file(self, mocked_repo):
-        assert mocked_repo.config_file is None
-
     def test_default_branch(self, mocked_repo):
         assert mocked_repo.default_branch == "master"
 
@@ -40,6 +37,9 @@ class TestRepoWithBranchDevelop(Contract):
 
     def test_repo(self, mocked_repo):
         assert mocked_repo.repo == "badge"
+
+    def test_repo_config_filename(self, mocked_repo):
+        assert mocked_repo.repo_config_filename is None
 
     def test_url(self, mocked_repo):
         assert mocked_repo.url == "https://github.com/fair-software/badge"

--- a/tests/github/fair_software/badge/test_repo_with_branch_sha.py
+++ b/tests/github/fair_software/badge/test_repo_with_branch_sha.py
@@ -19,9 +19,6 @@ class TestRepoWithBranchSHA(Contract):
     def test_branch(self, mocked_repo):
         assert mocked_repo.branch == "b3f90ec9c2b1be604f482c2d9e46a9aeca3ee45a"
 
-    def test_config_file(self, mocked_repo):
-        assert mocked_repo.config_file is None
-
     def test_default_branch(self, mocked_repo):
         assert mocked_repo.default_branch == "master"
 
@@ -40,6 +37,9 @@ class TestRepoWithBranchSHA(Contract):
 
     def test_repo(self, mocked_repo):
         assert mocked_repo.repo == "badge"
+
+    def test_repo_config_filename(self, mocked_repo):
+        assert mocked_repo.repo_config_filename is None
 
     def test_url(self, mocked_repo):
         assert mocked_repo.url == "https://github.com/fair-software/badge"

--- a/tests/github/fair_software/badge/test_repo_with_branch_tag.py
+++ b/tests/github/fair_software/badge/test_repo_with_branch_tag.py
@@ -19,9 +19,6 @@ class TestRepoWithBranchTag(Contract):
     def test_branch(self, mocked_repo):
         assert mocked_repo.branch == "0.1.0"
 
-    def test_config_file(self, mocked_repo):
-        assert mocked_repo.config_file is None
-
     def test_default_branch(self, mocked_repo):
         assert mocked_repo.default_branch == "master"
 
@@ -40,6 +37,9 @@ class TestRepoWithBranchTag(Contract):
 
     def test_repo(self, mocked_repo):
         assert mocked_repo.repo == "badge"
+
+    def test_repo_config_filename(self, mocked_repo):
+        assert mocked_repo.repo_config_filename is None
 
     def test_url(self, mocked_repo):
         assert mocked_repo.url == "https://github.com/fair-software/badge"

--- a/tests/github/fair_software/badge/test_repo_with_config.py
+++ b/tests/github/fair_software/badge/test_repo_with_config.py
@@ -8,7 +8,7 @@ from .mocker import mocker
 @pytest.fixture
 def mocked_repo(mocker):
     with mocker:
-        return Repo("https://github.com/fair-software/badge", config_file=".howfairis-custom-config.yml")
+        return Repo("https://github.com/fair-software/badge", repo_config_filename=".howfairis.custom.yml")
 
 
 class TestRepoWithConfig(Contract):
@@ -18,9 +18,6 @@ class TestRepoWithConfig(Contract):
 
     def test_branch(self, mocked_repo):
         assert mocked_repo.branch is None
-
-    def test_config_file(self, mocked_repo):
-        assert mocked_repo.config_file == ".howfairis-custom-config.yml"
 
     def test_default_branch(self, mocked_repo):
         assert mocked_repo.default_branch == "master"
@@ -40,6 +37,9 @@ class TestRepoWithConfig(Contract):
 
     def test_repo(self, mocked_repo):
         assert mocked_repo.repo == "badge"
+
+    def test_repo_config_filename(self, mocked_repo):
+        assert mocked_repo.repo_config_filename == ".howfairis.custom.yml"
 
     def test_url(self, mocked_repo):
         assert mocked_repo.url == "https://github.com/fair-software/badge"

--- a/tests/github/fair_software/badge/test_repo_with_path.py
+++ b/tests/github/fair_software/badge/test_repo_with_path.py
@@ -19,9 +19,6 @@ class TestRepoWithPath(Contract):
     def test_branch(self, mocked_repo):
         assert mocked_repo.branch is None
 
-    def test_config_file(self, mocked_repo):
-        assert mocked_repo.config_file is None
-
     def test_default_branch(self, mocked_repo):
         assert mocked_repo.default_branch == "master"
 
@@ -40,6 +37,9 @@ class TestRepoWithPath(Contract):
 
     def test_repo(self, mocked_repo):
         assert mocked_repo.repo == "badge"
+
+    def test_repo_config_filename(self, mocked_repo):
+        assert mocked_repo.repo_config_filename is None
 
     def test_url(self, mocked_repo):
         assert mocked_repo.url == "https://github.com/fair-software/badge"

--- a/tests/gitlab/jspaaks/badge_test/test_repo_no_args.py
+++ b/tests/gitlab/jspaaks/badge_test/test_repo_no_args.py
@@ -19,9 +19,6 @@ class TestRepoNoArgs(Contract):
     def test_branch(self, mocked_repo):
         assert mocked_repo.branch is None
 
-    def test_config_file(self, mocked_repo):
-        assert mocked_repo.config_file is None
-
     def test_default_branch(self, mocked_repo):
         assert mocked_repo.default_branch == "master"
 
@@ -39,6 +36,9 @@ class TestRepoNoArgs(Contract):
 
     def test_repo(self, mocked_repo):
         assert mocked_repo.repo == "badge-test"
+
+    def test_repo_config_filename(self, mocked_repo):
+        assert mocked_repo.repo_config_filename is None
 
     def test_url(self, mocked_repo):
         assert mocked_repo.url == "https://gitlab.com/jspaaks/badge-test"

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -9,19 +9,19 @@ from howfairis.readme import Readme
 
 @pytest.fixture
 def badghurl_checker(requests_mock: Mocker):
-    requests_mock.get('https://raw.githubusercontent.com/fair-software/does-not-exist/main/.howfairis.yml', status_code=404)
-    requests_mock.get('https://raw.githubusercontent.com/fair-software/does-not-exist/main/.howfairis.yml', status_code=404)
-    requests_mock.get('https://raw.githubusercontent.com/fair-software/does-not-exist/main/README.md', status_code=404)
-    requests_mock.get('https://raw.githubusercontent.com/fair-software/does-not-exist/main/README.rst', status_code=404)
-    requests_mock.get('https://api.github.com/repos/fair-software/does-not-exist', status_code=404)
-    requests_mock.get('https://api.github.com/repos/fair-software/does-not-exist/license', status_code=404)
-    requests_mock.get('https://github.com/fair-software/does-not-exist', status_code=404)
-    requests_mock.get('https://raw.githubusercontent.com/fair-software/does-not-exist/main/CITATION', status_code=404)
-    requests_mock.get('https://raw.githubusercontent.com/fair-software/does-not-exist/main/CITATION.cff', status_code=404)
-    requests_mock.get('https://raw.githubusercontent.com/fair-software/does-not-exist/main/codemeta.json', status_code=404)
-    requests_mock.get('https://raw.githubusercontent.com/fair-software/does-not-exist/main/.zenodo.json', status_code=404)
+    requests_mock.get("https://raw.githubusercontent.com/fair-software/does-not-exist/main/.howfairis.yml", status_code=404)
+    requests_mock.get("https://raw.githubusercontent.com/fair-software/does-not-exist/main/.howfairis.yml", status_code=404)
+    requests_mock.get("https://raw.githubusercontent.com/fair-software/does-not-exist/main/README.md", status_code=404)
+    requests_mock.get("https://raw.githubusercontent.com/fair-software/does-not-exist/main/README.rst", status_code=404)
+    requests_mock.get("https://api.github.com/repos/fair-software/does-not-exist", status_code=404)
+    requests_mock.get("https://api.github.com/repos/fair-software/does-not-exist/license", status_code=404)
+    requests_mock.get("https://github.com/fair-software/does-not-exist", status_code=404)
+    requests_mock.get("https://raw.githubusercontent.com/fair-software/does-not-exist/main/CITATION", status_code=404)
+    requests_mock.get("https://raw.githubusercontent.com/fair-software/does-not-exist/main/CITATION.cff", status_code=404)
+    requests_mock.get("https://raw.githubusercontent.com/fair-software/does-not-exist/main/codemeta.json", status_code=404)
+    requests_mock.get("https://raw.githubusercontent.com/fair-software/does-not-exist/main/.zenodo.json", status_code=404)
 
-    repo = Repo('https://github.com/fair-software/does-not-exist')
+    repo = Repo("https://github.com/fair-software/does-not-exist")
     config = Config(repo)
     checker = Checker(config, repo)
     return checker

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,9 +4,9 @@ from howfairis import Config, Repo
 
 
 def test_config_withoutrepoconfig_shouldusedefault(requests_mock: Mocker):
-    requests_mock.get('https://api.github.com/repos/fair-software/howfairis', json={'default_branch': 'master'} )
-    requests_mock.get('https://raw.githubusercontent.com/fair-software/howfairis/master/.howfairis.yml', status_code=404)
-    repo = Repo('https://github.com/fair-software/howfairis')
+    requests_mock.get("https://api.github.com/repos/fair-software/howfairis", json={"default_branch": "master"} )
+    requests_mock.get("https://raw.githubusercontent.com/fair-software/howfairis/master/.howfairis.yml", status_code=404)
+    repo = Repo("https://github.com/fair-software/howfairis")
     config = Config(repo)
 
     assert config.force_checklist is None, "config not same as `howfairis/data/.howfairis.yml`"

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -4,14 +4,14 @@ from howfairis.code_repository_platforms import Platform
 
 
 def test_notfound_url(requests_mock: Mocker):
-    requests_mock.get('https://api.github.com/repos/fair-software/does-not-exist', status_code=404)
+    requests_mock.get("https://api.github.com/repos/fair-software/does-not-exist", status_code=404)
 
-    repo = Repo('https://github.com/fair-software/does-not-exist')
-    assert repo.platform == Platform.GITHUB, 'platform not GitHub'
+    repo = Repo("https://github.com/fair-software/does-not-exist")
+    assert repo.platform == Platform.GITHUB, "platform not GitHub"
 
 
 def test_github_platform(requests_mock: Mocker):
-    requests_mock.get('https://api.github.com/repos/fair-software/howfairis', json={'default_branch': 'master'} )
+    requests_mock.get("https://api.github.com/repos/fair-software/howfairis", json={"default_branch": "master"} )
 
-    repo = Repo('https://github.com/fair-software/howfairis')
-    assert repo.platform == Platform.GITHUB, 'platform not GitHub'
+    repo = Repo("https://github.com/fair-software/howfairis")
+    assert repo.platform == Platform.GITHUB, "platform not GitHub"


### PR DESCRIPTION
**List of related issues or pull requests**

Refs: -

**Describe the changes made in this pull request**

In this PR, I updated the variable names in `Repo` to be more precise. In particular, 
- I changed `*_file` to `*_filename` to indicate these variables are strings, not `File` objects or something.
- I prepended any `*_config_filename` and `*_config` variables with prefixes `[default|repo|user]` indicating where each configuration originates.

**Instructions to review the pull request**

&nbsp;