### PR TITLE
Update badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Live tests (triggered manually)                        |workflow livetests badge
    :target: https://doi.org/10.5281/zenodo.4017908
    
 .. |core infrastructures badge| image:: https://bestpractices.coreinfrastructure.org/projects/4630/badge
-   :target: https://bestpractices.coreinfrastructure.org/projects/4630
+   :target: https://bestpractices.coreinfrastructure.org/en/projects/4630
 
 .. |fair-software badge| image:: https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F-green
    :target: https://fair-software.eu
@@ -66,9 +66,9 @@ Live tests (triggered manually)                        |workflow livetests badge
    :target: https://sonarcloud.io/dashboard?id=fair-software_howfairis
    :alt: Coverage
 
-.. |dockerhub badge| image:: https://img.shields.io/docker/build/fairsoftware/howfairis
+.. |dockerhub badge| image:: https://img.shields.io/docker/pulls/fairsoftware/howfairis
    :target: https://hub.docker.com/r/fairsoftware/howfairis
-   :alt: Docker Build Status
+   :alt: Docker Pulls
 
 .. |workflow tests badge| image:: https://github.com/fair-software/howfairis/workflows/tests/badge.svg
    :target: https://github.com/fair-software/howfairis/actions?query=workflow%3Atests


### PR DESCRIPTION
best practices link when to login page. 

Docker badge used automated build image, while is build/pushed manually. Changed to pull counter.