### PR TITLE
Checker.repo_config_filename default to .howfairis.yml instead of None

### DIFF
--- a/howfairis/checker.py
+++ b/howfairis/checker.py
@@ -116,7 +116,9 @@ class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, Check
             if repo_config_filename != DEFAULT_CONFIG_FILENAME:
                 print("Using the configuration file {0}".format(raw_url))
         except requests.HTTPError as e:
-            raise Exception("Could not find the configuration file {0}".format(raw_url)) from e
+            if repo_config_filename != DEFAULT_CONFIG_FILENAME:
+                raise Exception("Could not find the configuration file {0}".format(raw_url)) from e
+            return dict()
 
         try:
             repo_config = YAML(typ="safe").load(response.text)

--- a/howfairis/checker.py
+++ b/howfairis/checker.py
@@ -114,7 +114,8 @@ class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, Check
             response = requests.get(raw_url)
             # If the response was successful, no Exception will be raised
             response.raise_for_status()
-            print("Using the configuration file {0}".format(raw_url))
+            if non_default_repo_config_filename:
+                print("Using the configuration file {0}".format(raw_url))
         except requests.HTTPError as e:
             if repo_config_filename != DEFAULT_CONFIG_FILENAME:
                 raise Exception("Could not find the configuration file {0}".format(raw_url)) from e

--- a/howfairis/checker.py
+++ b/howfairis/checker.py
@@ -18,6 +18,7 @@ from .readme_format import ReadmeFormat
 from .repo import Repo
 from .schema import validate_against_schema
 
+
 DEFAULT_CONFIG_FILENAME = ".howfairis.yml"
 
 

--- a/howfairis/checker.py
+++ b/howfairis/checker.py
@@ -109,7 +109,6 @@ class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, Check
             return dict()
 
         raw_url = repo.raw_url_format_string.format(repo_config_filename)
-        non_default_repo_config_filename = repo_config_filename != DEFAULT_CONFIG_FILENAME
 
         try:
             response = requests.get(raw_url)
@@ -117,7 +116,7 @@ class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, Check
             response.raise_for_status()
             print("Using the configuration file {0}".format(raw_url))
         except requests.HTTPError as e:
-            if non_default_repo_config_filename:
+            if repo_config_filename != DEFAULT_CONFIG_FILENAME:
                 raise Exception("Could not find the configuration file {0}".format(raw_url)) from e
             return dict()
 

--- a/howfairis/checker.py
+++ b/howfairis/checker.py
@@ -18,6 +18,8 @@ from .readme_format import ReadmeFormat
 from .repo import Repo
 from .schema import validate_against_schema
 
+DEFAULT_CONFIG_FILENAME = ".howfairis.yml"
+
 
 class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, ChecklistMixin):
     """Check the repo against the five FAIR software recommendations using supplied config.
@@ -31,7 +33,7 @@ class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, Check
     """
 
     # pylint: disable=too-many-arguments
-    def __init__(self, repo: Repo, user_config_filename=None, repo_config_filename=None,
+    def __init__(self, repo: Repo, user_config_filename=None, repo_config_filename=DEFAULT_CONFIG_FILENAME,
                  ignore_repo_config=False, is_quiet=False):
 
         super().__init__()
@@ -105,20 +107,16 @@ class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, Check
         if ignore_remote_config is True:
             return dict()
 
-        if repo_config_filename is None:
-            raw_url = repo.raw_url_format_string.format(".howfairis.yml")
-        else:
-            raw_url = repo.raw_url_format_string.format(repo_config_filename)
+        raw_url = repo.raw_url_format_string.format(repo_config_filename)
 
         try:
             response = requests.get(raw_url)
             # If the response was successful, no Exception will be raised
             response.raise_for_status()
-            print("Using the configuration file {0}".format(raw_url))
+            if repo_config_filename != DEFAULT_CONFIG_FILENAME:
+                print("Using the configuration file {0}".format(raw_url))
         except requests.HTTPError as e:
-            if repo_config_filename is not None:
-                raise Exception("Could not find the configuration file {0}".format(raw_url)) from e
-            return dict()
+            raise Exception("Could not find the configuration file {0}".format(raw_url)) from e
 
         try:
             repo_config = YAML(typ="safe").load(response.text)

--- a/howfairis/checker.py
+++ b/howfairis/checker.py
@@ -109,6 +109,7 @@ class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, Check
             return dict()
 
         raw_url = repo.raw_url_format_string.format(repo_config_filename)
+        non_default_repo_config_filename = repo_config_filename != DEFAULT_CONFIG_FILENAME
 
         try:
             response = requests.get(raw_url)
@@ -117,7 +118,7 @@ class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, Check
             if non_default_repo_config_filename:
                 print("Using the configuration file {0}".format(raw_url))
         except requests.HTTPError as e:
-            if repo_config_filename != DEFAULT_CONFIG_FILENAME:
+            if non_default_repo_config_filename:
                 raise Exception("Could not find the configuration file {0}".format(raw_url)) from e
             return dict()
 

--- a/howfairis/checker.py
+++ b/howfairis/checker.py
@@ -115,8 +115,7 @@ class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, Check
             response = requests.get(raw_url)
             # If the response was successful, no Exception will be raised
             response.raise_for_status()
-            if non_default_repo_config_filename:
-                print("Using the configuration file {0}".format(raw_url))
+            print("Using the configuration file {0}".format(raw_url))
         except requests.HTTPError as e:
             if non_default_repo_config_filename:
                 raise Exception("Could not find the configuration file {0}".format(raw_url)) from e

--- a/howfairis/checker.py
+++ b/howfairis/checker.py
@@ -108,15 +108,16 @@ class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, Check
             return dict()
 
         raw_url = repo.raw_url_format_string.format(repo_config_filename)
+        non_default_repo_config_filename = repo_config_filename != DEFAULT_CONFIG_FILENAME
 
         try:
             response = requests.get(raw_url)
             # If the response was successful, no Exception will be raised
             response.raise_for_status()
-            if repo_config_filename != DEFAULT_CONFIG_FILENAME:
+            if non_default_repo_config_filename:
                 print("Using the configuration file {0}".format(raw_url))
         except requests.HTTPError as e:
-            if repo_config_filename != DEFAULT_CONFIG_FILENAME:
+            if non_default_repo_config_filename:
                 raise Exception("Could not find the configuration file {0}".format(raw_url)) from e
             return dict()
 

--- a/howfairis/cli/cli.py
+++ b/howfairis/cli/cli.py
@@ -2,7 +2,7 @@ import sys
 import click
 from colorama import init as init_terminal_colors
 from howfairis.__version__ import __version__
-from howfairis.checker import Checker
+from howfairis.checker import Checker, DEFAULT_CONFIG_FILENAME
 from howfairis.cli.print_call_to_action import print_call_to_action
 from howfairis.cli.print_default_config import print_default_config
 from howfairis.cli.print_feedback_about_config_args import print_feedback_about_config_args
@@ -27,7 +27,7 @@ from howfairis.repo import Repo
                    "README and a configuration file in a subdirectory.")
 @click.option("-q", "--quiet", default=False, is_flag=True,
               help="Use this flag to disable all printing except errors.")
-@click.option("-r", "--repo-config-filename", default=None, type=click.STRING,
+@click.option("-r", "--repo-config-filename", default=DEFAULT_CONFIG_FILENAME, type=click.STRING,
               help="Name of the configuration file to control howfairis'es behavior. The configuration " +
                    "file needs to be on the remote, and takes into account the value of " +
                    "--branch and --path. Default: .howfairis.yml")

--- a/howfairis/cli/cli.py
+++ b/howfairis/cli/cli.py
@@ -2,7 +2,8 @@ import sys
 import click
 from colorama import init as init_terminal_colors
 from howfairis.__version__ import __version__
-from howfairis.checker import Checker, DEFAULT_CONFIG_FILENAME
+from howfairis.checker import DEFAULT_CONFIG_FILENAME
+from howfairis.checker import Checker
 from howfairis.cli.print_call_to_action import print_call_to_action
 from howfairis.cli.print_default_config import print_default_config
 from howfairis.cli.print_feedback_about_config_args import print_feedback_about_config_args

--- a/howfairis/cli/print_feedback_about_config_args.py
+++ b/howfairis/cli/print_feedback_about_config_args.py
@@ -1,10 +1,13 @@
+from howfairis.checker import DEFAULT_CONFIG_FILENAME
+
+
 def print_feedback_about_config_args(ignore_repo_config, repo_config_filename, user_config_filename, is_quiet=False):
 
     if not is_quiet:
         if ignore_repo_config is True:
             print("Ignoring any configuration files on the remote.")
 
-        if ignore_repo_config is False and repo_config_filename is not None:
+        if ignore_repo_config is False and repo_config_filename != DEFAULT_CONFIG_FILENAME:
             print("Remote configuration filename: " + repo_config_filename)
 
         if user_config_filename is not None:


### PR DESCRIPTION
Refs #175

**Describe the changes made in this pull request**

**Instructions to review the pull request**

Test against a badge-test repo:
```shell
howfairis -p force/00100 https://github.com/fair-software/badge-test
# should print skip reason 

howfairis -r mycustom.howfairis.yml -p force/00100 https://github.com/fair-software/badge-test
# should die with `Not Found for url: https://raw.githubusercontent.com/fair-software/badge-test/master/force/00100/mycustom.howfairis.yml`
```