### PR TITLE
renamed license_ to repo_license; refs #236

### DIFF
--- a/howfairis/checker.py
+++ b/howfairis/checker.py
@@ -181,7 +181,7 @@ class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, Check
         After being called the :py:attr:`.Checker.compliance` property will be filled the the result of the check.
         """
         return Compliance(repository=self.check_repository(),
-                          license_=self.check_license(),
+                          repo_license=self.check_repo_license(),
                           registry=self.check_registry(),
                           citation=self.check_citation(),
                           checklist=self.check_checklist())

--- a/howfairis/compliance.py
+++ b/howfairis/compliance.py
@@ -8,7 +8,7 @@ class Compliance:
 
     Attributes:
         repository: Whether repository is publicly accessible with version control
-        license: Whether repository has a license
+        repo_license: Whether repository has a license
         registry: Whether code is in a registry
         citation: Whether software is citable
         checklist: Whether a software quality checklist is used
@@ -19,11 +19,11 @@ class Compliance:
     COMPLIANT_SYMBOL = "\u25CF"
     NONCOMPLIANT_SYMBOL = "\u25CB"
 
-    def __init__(self, repository=False, license_=False, registry=False, citation=False, checklist=False):
+    def __init__(self, repository=False, repo_license=False, registry=False, citation=False, checklist=False):
         self._index = 0
         self.checklist = checklist
         self.citation = citation
-        self.license = license_
+        self.repo_license = repo_license
         self.registry = registry
         self.repository = repository
 
@@ -43,7 +43,7 @@ class Compliance:
 
     @property
     def _state(self):
-        return [self.repository, self.license, self.registry,
+        return [self.repository, self.repo_license, self.registry,
                 self.citation, self.checklist]
 
     def as_unicode(self):

--- a/howfairis/mixins/license_mixin.py
+++ b/howfairis/mixins/license_mixin.py
@@ -5,7 +5,7 @@ from ..code_repository_platforms import Platform
 
 class LicenseMixin:
 
-    def check_license(self):
+    def check_repo_license(self):
         if not self.is_quiet:
             print("(2/5) license:")
         reason = self.skip_license_checks_reason

--- a/howfairis/readme.py
+++ b/howfairis/readme.py
@@ -40,7 +40,7 @@ class Readme:
             "-" \
             "(?P<repository>(" + Readme.COMPLIANT_SYMBOL + "|" + Readme.NONCOMPLIANT_SYMBOL + "))" \
             "(?:" + Readme.SEPARATOR + ")" \
-            "(?P<license>(" + Readme.COMPLIANT_SYMBOL + "|" + Readme.NONCOMPLIANT_SYMBOL + "))" \
+            "(?P<repo_license>(" + Readme.COMPLIANT_SYMBOL + "|" + Readme.NONCOMPLIANT_SYMBOL + "))" \
             "(?:" + Readme.SEPARATOR + ")" \
             "(?P<registry>(" + Readme.COMPLIANT_SYMBOL + "|" + Readme.NONCOMPLIANT_SYMBOL + "))" \
             "(?:" + Readme.SEPARATOR + ")" \
@@ -58,7 +58,7 @@ class Readme:
         groupdict = matched.groupdict()
 
         return Compliance(repository=groupdict.get("repository") == Readme.COMPLIANT_SYMBOL,
-                          license_=groupdict.get("license") == Readme.COMPLIANT_SYMBOL,
+                          repo_license=groupdict.get("repo_license") == Readme.COMPLIANT_SYMBOL,
                           registry=groupdict.get("registry") == Readme.COMPLIANT_SYMBOL,
                           citation=groupdict.get("citation") == Readme.COMPLIANT_SYMBOL,
                           checklist=groupdict.get("checklist") == Readme.COMPLIANT_SYMBOL)

--- a/tests/contracts/checker.py
+++ b/tests/contracts/checker.py
@@ -13,11 +13,11 @@ class Contract(ABC):
         pass
 
     @abstractmethod
-    def test_check_license(self, mocked_context: Mocker):
+    def test_check_registry(self, mocked_context: Mocker):
         pass
 
     @abstractmethod
-    def test_check_registry(self, mocked_context: Mocker):
+    def test_check_repo_license(self, mocked_context: Mocker):
         pass
 
     @abstractmethod

--- a/tests/contracts/compliance.py
+++ b/tests/contracts/compliance.py
@@ -37,11 +37,11 @@ class Contract(ABC):
         pass
 
     @abstractmethod
-    def test_license(self, compliance_fixture: Compliance):
+    def test_registry(self, compliance_fixture: Compliance):
         pass
 
     @abstractmethod
-    def test_registry(self, compliance_fixture: Compliance):
+    def test_repo_license(self, compliance_fixture: Compliance):
         pass
 
     @abstractmethod

--- a/tests/github/repo1/test_checker_no_args.py
+++ b/tests/github/repo1/test_checker_no_args.py
@@ -22,15 +22,15 @@ class TestCheckerNoArgs(Contract):
             mocked_checker = get_mocked_checker()
             assert mocked_checker.check_citation() is True
 
-    def test_check_license(self, mocker):
-        with mocker:
-            mocked_checker = get_mocked_checker()
-            assert mocked_checker.check_license() is True
-
     def test_check_registry(self, mocker):
         with mocker:
             mocked_checker = get_mocked_checker()
             assert mocked_checker.check_registry() is True
+
+    def test_check_repo_license(self, mocker):
+        with mocker:
+            mocked_checker = get_mocked_checker()
+            assert mocked_checker.check_repo_license() is True
 
     def test_check_repository(self, mocker):
         with mocker:

--- a/tests/github/repo1/test_checker_with_noreason_user_config.py
+++ b/tests/github/repo1/test_checker_with_noreason_user_config.py
@@ -33,17 +33,17 @@ class TestCheckerWithReasonableUserConfig(Contract):
             captured = capsys.readouterr()
             assert "no reason provided" in captured.out
 
-    def test_check_license(self, mocker: Mocker, user_config, capsys):
-        with mocker:
-            checker = get_checker(user_config)
-            assert checker.check_license() is True
-            captured = capsys.readouterr()
-            assert "no reason provided" in captured.out
-
     def test_check_registry(self, mocker: Mocker, user_config, capsys):
         with mocker:
             checker = get_checker(user_config)
             assert checker.check_registry() is True
+            captured = capsys.readouterr()
+            assert "no reason provided" in captured.out
+
+    def test_check_repo_license(self, mocker: Mocker, user_config, capsys):
+        with mocker:
+            checker = get_checker(user_config)
+            assert checker.check_repo_license() is True
             captured = capsys.readouterr()
             assert "no reason provided" in captured.out
 

--- a/tests/github/repo1/test_checker_with_reasonable_user_config.py
+++ b/tests/github/repo1/test_checker_with_reasonable_user_config.py
@@ -33,19 +33,19 @@ class TestCheckerWithReasonableUserConfig(Contract):
             captured = capsys.readouterr()
             assert "dunno4" in captured.out
 
-    def test_check_license(self, mocker: Mocker, user_config, capsys):
-        with mocker:
-            checker = get_checker(user_config)
-            assert checker.check_license() is True
-            captured = capsys.readouterr()
-            assert "dunno2" in captured.out
-
     def test_check_registry(self, mocker: Mocker, user_config, capsys):
         with mocker:
             checker = get_checker(user_config)
             assert checker.check_registry() is True
             captured = capsys.readouterr()
             assert "dunno3" in captured.out
+
+    def test_check_repo_license(self, mocker: Mocker, user_config, capsys):
+        with mocker:
+            checker = get_checker(user_config)
+            assert checker.check_repo_license() is True
+            captured = capsys.readouterr()
+            assert "dunno2" in captured.out
 
     def test_check_repository(self, mocker: Mocker, user_config, capsys):
         with mocker:

--- a/tests/gitlab/repo1/test_checker_no_args.py
+++ b/tests/gitlab/repo1/test_checker_no_args.py
@@ -22,15 +22,15 @@ class TestCheckerNoArgs(Contract):
             mocked_checker = get_mocked_checker()
             assert mocked_checker.check_citation() is True
 
-    def test_check_license(self, mocker):
-        with mocker:
-            mocked_checker = get_mocked_checker()
-            assert mocked_checker.check_license() is True
-
     def test_check_registry(self, mocker):
         with mocker:
             mocked_checker = get_mocked_checker()
             assert mocked_checker.check_registry() is True
+
+    def test_check_repo_license(self, mocker):
+        with mocker:
+            mocked_checker = get_mocked_checker()
+            assert mocked_checker.check_repo_license() is True
 
     def test_check_repository(self, mocker):
         with mocker:

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -7,6 +7,6 @@ def test_get_compliance():
     text = "some bogus text here but then we see the badge https://img.shields.io/badge/fair--software.eu-" + \
            "%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8B-yellow with some trailing stuff."
     actual_compliance = Readme(filename="README.md", text=text, file_format=ReadmeFormat.MARKDOWN).get_compliance()
-    expected_compliance = Compliance(repository=True, license_=True, registry=True, citation=True, checklist=False)
+    expected_compliance = Compliance(repository=True, repo_license=True, registry=True, citation=True, checklist=False)
     assert actual_compliance == expected_compliance
 

--- a/tests/test_compliance_no_args.py
+++ b/tests/test_compliance_no_args.py
@@ -45,11 +45,11 @@ class TestComplianceNoArgs(Contract):
         for expected_compliance in expected_compliances:
             assert expected_compliance != compliance_fixture
 
-    def test_license(self, compliance_fixture):
-        assert compliance_fixture.license is False
-
     def test_registry(self, compliance_fixture):
         assert compliance_fixture.registry is False
+
+    def test_repo_license(self, compliance_fixture):
+        assert compliance_fixture.repo_license is False
 
     def test_repository(self, compliance_fixture):
         assert compliance_fixture.repository is False


### PR DESCRIPTION
**List of related issues or pull requests**

Refs: #236

**Describe the changes made in this pull request**

`Compliance` has a arg named `license_`, whose trailing underscore is easy to miss. Since the license applies to all of the repo, not subpaths or branches, it may be nice to solve two problems at once by renaming `license_` to `repo_license`. 

**Instructions to review the pull request**
