### PR TITLE
trying to calculate compliance of a readme that's None should return None

### DIFF
--- a/howfairis/checker.py
+++ b/howfairis/checker.py
@@ -111,7 +111,8 @@ class Checker(RepositoryMixin, LicenseMixin, RegistryMixin, CitationMixin, Check
             return Readme(filename=readme_filename, text=response.text, file_format=readme_file_format,
                           ignore_commented_badges=self.ignore_commented_badges)
 
-        print("Did not find a README[.md|.rst] file at " + raw_url.replace(readme_filename, ""))
+        print("\nDid not find a README[.md|.rst] file at {0}\nProceeding without it -- expect the"
+              " compliance to suffer.\n".format(raw_url.replace(readme_filename, "")))
 
         return Readme(filename=None, text=None, file_format=None)
 

--- a/howfairis/cli/print_call_to_action.py
+++ b/howfairis/cli/print_call_to_action.py
@@ -1,5 +1,10 @@
 def print_call_to_action(previous_compliance, current_compliance, readme, is_quiet=False):
 
+    if readme.text is None:
+        if not is_quiet:
+            print("\nIt seems you have not yet added a README[.md|.rst] file to your project.")
+        return 1
+
     badge = current_compliance.calc_badge(readme.file_format)
 
     if not is_quiet:

--- a/howfairis/cli/print_call_to_action.py
+++ b/howfairis/cli/print_call_to_action.py
@@ -1,8 +1,6 @@
 def print_call_to_action(previous_compliance, current_compliance, readme, is_quiet=False):
 
     if readme.text is None:
-        if not is_quiet:
-            print("\nIt seems you have not yet added a README[.md|.rst] file to your project.")
         return 1
 
     badge = current_compliance.calc_badge(readme.file_format)

--- a/howfairis/readme.py
+++ b/howfairis/readme.py
@@ -35,6 +35,10 @@ class Readme:
         return self
 
     def get_compliance(self):
+
+        if self.text is None:
+            return None
+
         s = r"(?P<skip>^.*)" \
             "(?P<base>https://img.shields.io/badge/fair--software.eu)" \
             "-" \


### PR DESCRIPTION
**List of related issues or pull requests**

Refs: #252

**Describe the changes made in this pull request**

`Readme.get_compliance()` now returns `None` if there isnt a `README[.md|.rst]` at the expected location. `cli` warns (now more prominently) about the README not being found, doesnt give TypeError anymore.

**Instructions to review the pull request**

e.g.

```shell
howfairis -p force/00001 https://github.com/fair-software/badge-test
Checking compliance with fair-software.eu...
url: https://github.com/fair-software/badge-test
path: force/00001

Did not find a README[.md|.rst] file at https://raw.githubusercontent.com/fair-software/badge-test/master/force/00001/
Proceeding without it -- expect the compliance to suffer.

(1/5) repository
      ✓ has_open_repository
(2/5) license
      ✓ has_license
(3/5) registry
      × has_ascl_badge
      × has_bintray_badge
      × has_conda_badge
      × has_cran_badge
      × has_crates_badge
      × has_maven_badge
      × has_npm_badge
      × has_pypi_badge
      × has_rsd_badge
      × is_on_github_marketplace
(4/5) citation
      × has_citation_file
      × has_citationcff_file
      × has_codemeta_file
      × has_zenodo_badge
      × has_zenodo_metadata_file
(5/5) checklist
      × has_core_infrastructures_badge
```

