### PR TITLE
badge test rename

### DIFF
--- a/clitests/script.sh
+++ b/clitests/script.sh
@@ -59,7 +59,7 @@ echo -e "\n\n"
 
 
 # github
-SLEEP_DURATION=20
+SLEEP_DURATION=0
 eval_and_print_status "howfairis https://github.com/fair-software/howfairis-livetest"
 eval_and_print_status "howfairis https://github.com/fair-software/howfairis-livetest -p skipping/00100"
 eval_and_print_status "howfairis https://github.com/fair-software/howfairis-livetest -p skipping/10110"

--- a/clitests/script.sh
+++ b/clitests/script.sh
@@ -32,7 +32,6 @@ eval_and_print_status () {
 
 # For character encoding on Windows
 export PYTHONIOENCODING=UTF-8
-SLEEP_DURATION=20
 
 echo "-------------------------------------------------------------------------"
 echo "which howfairis:"
@@ -60,6 +59,7 @@ echo -e "\n\n"
 
 
 # github
+SLEEP_DURATION=20
 eval_and_print_status "howfairis https://github.com/fair-software/howfairis-livetest"
 eval_and_print_status "howfairis https://github.com/fair-software/howfairis-livetest -p skipping/00100"
 eval_and_print_status "howfairis https://github.com/fair-software/howfairis-livetest -p skipping/10110"
@@ -69,6 +69,7 @@ eval_and_print_status "howfairis https://github.com/fair-software/howfairis-live
 eval_and_print_status "howfairis https://github.com/fair-software/howfairis-livetest -p ignore_commented_badges"
 
 # gitlab
+SLEEP_DURATION=0
 eval_and_print_status "howfairis https://gitlab.com/jspaaks/howfairis-livetest"
 eval_and_print_status "howfairis https://gitlab.com/jspaaks/howfairis-livetest -p skipping/00100"
 eval_and_print_status "howfairis https://gitlab.com/jspaaks/howfairis-livetest -p skipping/10110"

--- a/clitests/script.sh
+++ b/clitests/script.sh
@@ -60,13 +60,13 @@ echo -e "\n\n"
 
 
 # github
-eval_and_print_status "howfairis https://github.com/fair-software/badge-test"
-eval_and_print_status "howfairis https://github.com/fair-software/badge-test -p force/00100"
-eval_and_print_status "howfairis https://github.com/fair-software/badge-test -p force/10110"
-eval_and_print_status "howfairis https://github.com/fair-software/badge-test -p force/11110"
-eval_and_print_status "howfairis https://github.com/fair-software/badge-test -p force/11111"
-eval_and_print_status "howfairis https://github.com/fair-software/badge-test -p force/uu1uu"
-eval_and_print_status "howfairis https://github.com/fair-software/badge-test -p ignore_commented_badges"
+eval_and_print_status "howfairis https://github.com/fair-software/howfairis-livetest"
+eval_and_print_status "howfairis https://github.com/fair-software/howfairis-livetest -p skipping/00100"
+eval_and_print_status "howfairis https://github.com/fair-software/howfairis-livetest -p skipping/10110"
+eval_and_print_status "howfairis https://github.com/fair-software/howfairis-livetest -p skipping/11110"
+eval_and_print_status "howfairis https://github.com/fair-software/howfairis-livetest -p skipping/11111"
+eval_and_print_status "howfairis https://github.com/fair-software/howfairis-livetest -p skipping/uu1uu"
+eval_and_print_status "howfairis https://github.com/fair-software/howfairis-livetest -p ignore_commented_badges"
 
 # gitlab
 eval_and_print_status "howfairis https://gitlab.com/jspaaks/badge-test"

--- a/clitests/script.sh
+++ b/clitests/script.sh
@@ -69,13 +69,13 @@ eval_and_print_status "howfairis https://github.com/fair-software/howfairis-live
 eval_and_print_status "howfairis https://github.com/fair-software/howfairis-livetest -p ignore_commented_badges"
 
 # gitlab
-eval_and_print_status "howfairis https://gitlab.com/jspaaks/badge-test"
-eval_and_print_status "howfairis https://gitlab.com/jspaaks/badge-test -p force/00100"
-eval_and_print_status "howfairis https://gitlab.com/jspaaks/badge-test -p force/10110"
-eval_and_print_status "howfairis https://gitlab.com/jspaaks/badge-test -p force/11110"
-eval_and_print_status "howfairis https://gitlab.com/jspaaks/badge-test -p force/11111"
-eval_and_print_status "howfairis https://gitlab.com/jspaaks/badge-test -p force/uu1uu"
-eval_and_print_status "howfairis https://gitlab.com/jspaaks/badge-test -p ignore_commented_badges"
+eval_and_print_status "howfairis https://gitlab.com/jspaaks/howfairis-livetest"
+eval_and_print_status "howfairis https://gitlab.com/jspaaks/howfairis-livetest -p skipping/00100"
+eval_and_print_status "howfairis https://gitlab.com/jspaaks/howfairis-livetest -p skipping/10110"
+eval_and_print_status "howfairis https://gitlab.com/jspaaks/howfairis-livetest -p skipping/11110"
+eval_and_print_status "howfairis https://gitlab.com/jspaaks/howfairis-livetest -p skipping/11111"
+eval_and_print_status "howfairis https://gitlab.com/jspaaks/howfairis-livetest -p skipping/uu1uu"
+eval_and_print_status "howfairis https://gitlab.com/jspaaks/howfairis-livetest -p ignore_commented_badges"
 
 echo "All commands succeeded."
 exit 0


### PR DESCRIPTION
**List of related issues or pull requests**

Refs: #295

**Describe the changes made in this pull request**

Updated the repository names and name of paths used for live testing the cli, after
- https://github.com/fair-software/badge-test changed its name to https://github.com/fair-software/howfairis-livetest and 
- https://githlab.com/jspaaks/badge-test changed its name to https://gitlab.com/jspaaks/howfairis-livetest

Also set the sleep duration to 0 for gitlab platfaorm, API rate limit there is plenty high

**Instructions to review the pull request**

```shell
git clone <this repo>
git checkout <this branch>
cd howfairis
python3 -m venv venv3
source venv3/bin/activate
pip3 install --editable --no-cache-dir .[dev]
bash clitests/script.sh
```
