### PR TITLE
Add local coverage calculation

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,17 @@
+[run]
+data_file = coverage/.coverage
+branch = true
+
+[paths]
+source = fairtally/
+
+[html]
+directory = coverage/htmlcov/
+
+[xml]
+output = coverage/coverage.xml
+
+[report]
+omit =
+    venv*
+    tests/*

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@
 
 docs/_build
 docs/apidocs
+
+
+# don't accidentally commit secrets like apikeys
+/**secret**

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@
 docs/_build
 docs/apidocs
 
+# ignore the coverage reports generated when running pylint with coverage calculation
+/coverage/.coverage
+/coverage/htmlcov/*
+/coverage/coverage.xml
+
 
 # don't accidentally commit secrets like apikeys
 /**secret**

--- a/coverage/README.md
+++ b/coverage/README.md
@@ -1,0 +1,31 @@
+# Coverage reporting
+
+The coverage reports will be written in this directory. After running `pytest`, the directory should look more or less like this:
+
+```text
+coverage/
+├── .coverage
+├── coverage.xml
+├── htmlcov
+│   ├── coverage_html.js
+│   ├── fairtally_check_py.html
+│   ├── fairtally_cli_py.html
+│   ├── fairtally___init___py.html
+│   ├── fairtally_redirect_stdout_stderr_py.html
+│   ├── fairtally_utils_py.html
+│   ├── fairtally___version___py.html
+│   ├── favicon_32.png
+│   ├── index.html
+│   ├── jquery.ba-throttle-debounce.min.js
+│   ├── jquery.hotkeys.js
+│   ├── jquery.isonscreen.js
+│   ├── jquery.min.js
+│   ├── jquery.tablesorter.min.js
+│   ├── keybd_closed.png
+│   ├── keybd_open.png
+│   ├── status.json
+│   └── style.css
+└── README.md
+```
+
+Everything except the README is generated (see configuration in `/.coveragerc`).

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,12 +19,9 @@ description-file = README.md
 [aliases]
 test = pytest
 
-[coverage:run]
-branch = True
-source = howfairis
-
 [tool:pytest]
 testpaths = tests
+addopts = --cov --cov-config=.coveragerc --cov-report html --cov-report term --cov-report xml
 
 [tool:isort]
 lines_after_imports = 2


### PR DESCRIPTION
**List of related issues or pull requests**

Refs: -

**Describe the changes made in this pull request**

Added local coverage calculation

**Instructions to review the pull request**

in activated venv,

```
pytest
```

- should run the unit tests, then print an overview of locally calculated coverage
- `coverage/.coverage` should appear
- `coverage/coverage.xml` should appear
- `coverage/htmlcov/` should appear
- `firefox coverage/htmlcov` should open Firefox with html formatted report on coverage

