### PR TITLE
Update get_apikeys_from_env_vars.py

### DIFF
--- a/howfairis/get_apikeys_from_env_vars.py
+++ b/howfairis/get_apikeys_from_env_vars.py
@@ -15,7 +15,7 @@ def get_apikeys_from_env_vars():
     if apikey_gitlab is None:
         gitlab_user, gitlab_key = None, None
     else:
-        gitlab_user, gitlab_key = apikey_github.split(":")
+        gitlab_user, gitlab_key = apikey_gitlab.split(":")
 
     return {
         "github-key": github_key,


### PR DESCRIPTION
**List of related issues or pull requests**

Refs: N/A

**Describe the changes made in this pull request**

Sonarcloud suggested to fix this

![image](https://user-images.githubusercontent.com/4558105/187484360-1a92e90d-1376-458a-9732-b428f0d0a1fd.png)

But really the issue is that we were using the github key when we should have been using the gitlab key

**Instructions to review the pull request**

- look at the diff
