### PR TITLE
Bump dockerfile, make build context smaller

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# exclude all local files from the Docker context...
+*
+
+# ... except the ones listed here
+!CITATION.cff
+!howfairis
+!LICENSE
+!MANIFEST.in
+!NOTICE
+!README.rst
+!setup.cfg
+!setup.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM python:alpine3.9
+FROM python:3.10.6-alpine3.16
 COPY . /app
 WORKDIR /app
-RUN pip install .
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install .
 ENTRYPOINT ["howfairis"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM python:3.10.6-alpine3.16
-COPY . /app
+
+COPY . /app    
+# see also .dockerignore
+
 WORKDIR /app
+
 RUN python3 -m pip install --upgrade pip && \
     python3 -m pip install .
+
 ENTRYPOINT ["howfairis"]

--- a/README.dev.rst
+++ b/README.dev.rst
@@ -17,14 +17,12 @@ Development install
     # activate virtualenv
     source venv3/bin/activate
     
-    # make sure to have a recent version of pip
-    pip install --upgrade pip 
+    # make sure to have a recent version of pip, wheel, setuptools
+    python3 -m pip install --upgrade pip wheel setuptools
 
     # (from the project root directory)
-    # install howfairis as an editable package
-    pip install --no-cache-dir --editable .
-    # install development dependencies
-    pip install --no-cache-dir --editable .[dev]
+    # install howfairis as an editable package, with development dependencies
+    python3 -m pip install --no-cache-dir --editable .[dev]
 
 Afterwards check that the install directory was added to the ``PATH``
 environment variable. You should then be able to call the executable,
@@ -122,19 +120,18 @@ In a new terminal, without an activated virtual environment or a venv3 directory
     python3 -m venv venv3
     source venv3/bin/activate
     
-    # make sure to have a recent version of pip
-    pip install --upgrade pip 
+    # make sure to have a recent version of pip, wheel, setuptools
+    python3 -m pip install --upgrade pip wheel setuptools
 
     # install runtime dependencies and publishing dependencies
-    pip install --no-cache-dir .
-    pip install --no-cache-dir .[publishing]
+    python3 -m pip install --no-cache-dir .[publishing]
     
     # clean up any previously generated artefacts 
     rm -rf howfairis.egg-info
     rm -rf dist
     
     # create the source distribution and the wheel
-    python setup.py sdist bdist_wheel
+    python3 setup.py sdist bdist_wheel
 
     # upload to test pypi instance (requires credentials)
     twine upload --repository-url https://test.pypi.org/legacy/ dist/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ search = version: "{current_version}"
 replace = version: "{new_version}"
 
 [metadata]
-description_file = README.md
+description_file = README.rst
 
 [aliases]
 test = pytest


### PR DESCRIPTION
**List of related issues or pull requests**

Refs: N/A

**Describe the changes made in this pull request**

Updated `Dockerfile`:

1. now uses a more recent `FROM` image, now using python 3.10.6 and alpine 3.16 
2. updates `pip` before installing the package
3. smaller Docker context using `.dockerignore` (< 0.5MB, was >120MB)
4. some minor doc changes

**Instructions to review the pull request**

(have a working docker installation)

```shell
# make a temp directory, cd into it
cd $(mktemp -d --tmpdir howfairis.XXXXXX)

# get a copy of the repo
git clone https://github.com/fair-software/howfairis .

# checkout the branch
git checkout bump-dockerfile

# build howfairis docker image
docker build -t fairsoftware/howfairis:latest .

# run an example on github and on gitlab
docker run -ti --rm fairsoftware/howfairis:latest https://github.com/fair-software/howfairis-livetest
docker run -ti --rm fairsoftware/howfairis:latest https://gitlab.com/jspaaks/howfairis-livetest

# look inside the docker container if everything looks OK
docker run -ti --rm --entrypoint /bin/sh fairsoftware/howfairis:latest 
apk add tree 
tree -a
```
