### PR TITLE
add function to automate badge update

### DIFF
--- a/howfairis/cli/cli.py
+++ b/howfairis/cli/cli.py
@@ -4,7 +4,7 @@ from colorama import init as init_terminal_colors
 from howfairis.__version__ import __version__
 from howfairis.checker import DEFAULT_CONFIG_FILENAME
 from howfairis.checker import Checker
-from howfairis.cli.print_call_to_action import print_call_to_action
+from howfairis.cli.print_call_to_action import print_call_to_action, automate_call_to_action
 from howfairis.cli.print_default_config import print_default_config
 from howfairis.cli.print_feedback_about_config_args import print_feedback_about_config_args
 from howfairis.cli.print_feedback_about_repo_args import print_feedback_about_repo_args
@@ -14,6 +14,8 @@ from howfairis.repo import Repo
 
 # pylint: disable=too-many-arguments
 @click.command(context_settings=dict(help_option_names=["-h", "--help"]))
+@click.option("-a", "--auto", default=False, is_flag=True,
+              help="Automatically update fair-software.eu badge in local README.")
 @click.option("-b", "--branch", default=None, type=click.STRING,
               help="Which git branch to use. Also accepts other git references like SHA or tag.")
 @click.option("-u", "--user-config-filename", default=None, type=click.Path(),
@@ -37,7 +39,7 @@ from howfairis.repo import Repo
 @click.option("-v", "--version", default=False, is_flag=True,
               help="Show version and exit.")
 @click.argument("url", required=False)
-def cli(url=None, branch=None, user_config_filename=None, repo_config_filename=None, path=None,
+def cli(url=None, auto=False, branch=None, user_config_filename=None, repo_config_filename=None, path=None,
         show_trace=False, version=False, ignore_repo_config=False, show_default_config=False, quiet=False):
 
     """Determine compliance with recommendations from fair-software.eu for the repository at URL. The following
@@ -70,7 +72,10 @@ def cli(url=None, branch=None, user_config_filename=None, repo_config_filename=N
     previous_compliance = checker.readme.get_compliance()
     current_compliance = checker.check_five_recommendations()
 
-    sys.exit(print_call_to_action(previous_compliance, current_compliance, checker, is_quiet=quiet))
+    if not auto:
+        sys.exit(print_call_to_action(previous_compliance, current_compliance, checker, is_quiet=quiet))
+    else:
+        sys.exit(automate_call_to_action(previous_compliance, current_compliance, checker, is_quiet=quiet))
 
 
 if __name__ == "__main__":

--- a/howfairis/cli/print_call_to_action.py
+++ b/howfairis/cli/print_call_to_action.py
@@ -37,3 +37,37 @@ def print_call_to_action(previous_compliance, current_compliance, checker, is_qu
             github_caching_check(checker)
 
     return sys_exit_code
+
+
+def automate_call_to_action(previous_compliance, current_compliance, checker, is_quiet=False):
+    """ Function to automate the process of updating the fair-software.eu badge """
+    if checker.readme.text is None:
+        return 1
+
+    if previous_compliance is None:
+        badge = current_compliance.calc_badge(checker.readme.file_format)
+        message = "It seems you have not yet added the fair-software.eu badge to " + \
+                  f"your {checker.readme.filename}. You can do so by pasting the following snippet:\n\n{badge}"
+        sys_exit_code = 1
+
+    elif current_compliance == previous_compliance:
+        message = "Expected badge is equal to the actual badge. It's all good.\n"
+        sys_exit_code = 0
+
+    else:
+        message = "Repository has a fair-software.eu badge, but current compliance does not match the badge\n" + \
+                  f"Updating badge image URL in {checker.readme.filename}."
+        with open(checker.readme.filename, "r") as readme:
+            readme_contents = readme.read()
+        readme_contents = readme_contents.replace(previous_compliance.badge_image_url(), current_compliance.badge_image_url())
+        with open(checker.readme.filename, "w") as readme:
+            readme.write(readme_contents)
+        sys_exit_code = 0
+
+    if not is_quiet:
+        print("\nCalculated compliance: " + " ".join(current_compliance.as_unicode()) + "\n")
+        print(message)
+        if checker.repo.platform == Platform.GITHUB:
+            github_caching_check(checker)
+
+    return sys_exit_code


### PR DESCRIPTION
**List of related issues or pull requests**

Refs: #ISSUE_NUMBER

**Describe the changes made in this pull request**

I've made a very small addition to howfairis to make it possible to automate updating the fair-software.eu badge inside a project's README. The goal is to use howfairis inside a GitHub action that checks the compliance and directly updates the badge instead of failing the workflow.

To this end, the command line option "-a" or "--auto" has been added. As well as one function `automate_call_to_action` that has been adapted from the `print_call_to_action` function. If you want I'm happy to rename the module from `print_call_to_action.py` to just `call_to_action.py` or something similar, since the module does more than just printing now.

I have added a test for `automate_call_to_action` to `tests/test_cli.py`.

I have also tested the automation of using "howfairis --auto" inside a GitHub action workflow. The test repository is here:
https://github.com/benvanwerkhoven/gh-actions-test-release
The workflow file that automatically updates the badge is here:
https://github.com/benvanwerkhoven/gh-actions-test-release/blob/main/.github/workflows/update-fair-software-badge.yml
You can see the "actions user" has updated the README automatically:
https://github.com/benvanwerkhoven/gh-actions-test-release/commits/main
To test this I also had to modify the howfairis-github-action. I can make a pull request for those additions later. I think it would be nice to support a user-specified option in that action to allow the user to enable this automation.

It would work even slightly better if howfairis could be run in a local git repository. Because even if your local files are different howfairis only checks what's on github. In reality, only the check "has_open_repository" really needs the GitHub URL and even that could be extracted from local files using 'git remote -v'. This point is not really related to the pull request, I'll create a separate issue to discuss this idea.

**Instructions to review the pull request**

```shell
# make a new temporary directory and cd into it
cd $(mktemp -d --tmpdir howfairis.XXXXXX)

# get a copy of the repo
git clone https://github.com/fair-software/howfairis .

# checkout the work from this branch 
git checkout <this branch>

# create a virtual environment named venv3
python3 -m venv venv3

# activate the virtual environment
source venv3/bin/activate

# update pip and friends
python3 -m pip install --upgrade pip wheel setuptools

# install runtime dependencies
python3 -m pip install .

# and, if you need it, the development tools
python3 -m pip install .[dev]
```

Keep what you need from below, extend as necessary

```shell
# run the unit tests
pytest

# tests against a live infrastructure
pytest livetests/

# cli tests
bash clitests/script.sh

# run linter
prospector

# import style
isort --check-only howfairis

# any additional steps for checking
# I have added a test for the code to tests/test_cli.py which is ran by pytest, but if you'd like to do a 'live' test you can do a pull request to change the README.rst with the wrong badge on this repo:
git clone git@github.com:benvanwerkhoven/gh-actions-test-release.git
And the GitHub action workflow will correct the badge automatically after the pull request has been merged.

```

