### PR TITLE
A Conan badge as a proper listing in a registry

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,6 +133,7 @@ looks something like this:
     (3/5) registry
           × has_ascl_badge
           × has_bintray_badge
+          × has_conan_badge
           × has_conda_badge
           × has_cran_badge
           × has_crates_badge
@@ -302,6 +303,7 @@ The manual override will be reflected in the output, as follows:
     (3/5) registry
           × has_ascl_badge
           × has_bintray_badge
+          × has_conan_badge
           × has_conda_badge
           × has_cran_badge
           × has_crates_badge

--- a/howfairis/mixins/registry_mixin.py
+++ b/howfairis/mixins/registry_mixin.py
@@ -14,6 +14,7 @@ class RegistryMixin:
             results = [
                 self.has_ascl_badge(),
                 self.has_bintray_badge(),
+                self.has_conan_badge(),
                 self.has_conda_badge(),
                 self.has_cran_badge(),
                 self.has_crates_badge(),
@@ -41,6 +42,11 @@ class RegistryMixin:
         """ """
         regexes = [r"https://api\.bintray\.com/packages/.*/.*/.*/images/download\.svg",
                    r"https://img\.shields\.io/bintray/.*"]
+        return self._eval_regexes(regexes)
+
+    def has_conan_badge(self):
+        """ """
+        regexes = [r"https://img\.shields\.io/conan/.*"]
         return self._eval_regexes(regexes)
 
     def has_conda_badge(self):

--- a/tests/case1/github/snippets/cli-no-args.txt
+++ b/tests/case1/github/snippets/cli-no-args.txt
@@ -11,6 +11,7 @@ Proceeding without it -- expect the compliance to suffer.
 (3/5) registry
       × has_ascl_badge
       × has_bintray_badge
+      × has_conan_badge
       × has_conda_badge
       × has_cran_badge
       × has_crates_badge

--- a/tests/case1/github/snippets/cli-with-nonexistent-path.txt
+++ b/tests/case1/github/snippets/cli-with-nonexistent-path.txt
@@ -12,6 +12,7 @@ Proceeding without it -- expect the compliance to suffer.
 (3/5) registry
       × has_ascl_badge
       × has_bintray_badge
+      × has_conan_badge
       × has_conda_badge
       × has_cran_badge
       × has_crates_badge

--- a/tests/case1/github/test_checker_no_args.py
+++ b/tests/case1/github/test_checker_no_args.py
@@ -69,6 +69,11 @@ class TestCheckerNoArgs(Contract):
             checker = get_checker()
             assert checker.has_codemeta_file() is False
 
+    def test_has_conan_badge(self, mocker):
+        with mocker:
+            checker = get_checker()
+            assert checker.has_conan_badge() is False
+
     def test_has_conda_badge(self, mocker):
         with mocker:
             checker = get_checker()

--- a/tests/case1/github/test_checker_with_emptyreasons_user_config.py
+++ b/tests/case1/github/test_checker_with_emptyreasons_user_config.py
@@ -82,6 +82,11 @@ class TestCheckerWithEmptyReasonsUserConfig(Contract):
             checker = get_checker()
             assert checker.has_codemeta_file() is False
 
+    def test_has_conan_badge(self, mocker):
+        with mocker:
+            checker = get_checker()
+            assert checker.has_conan_badge() is False
+
     def test_has_conda_badge(self, mocker):
         with mocker:
             checker = get_checker()

--- a/tests/case1/github/test_checker_with_skipreasons_user_config.py
+++ b/tests/case1/github/test_checker_with_skipreasons_user_config.py
@@ -82,6 +82,11 @@ class TestCheckerWithSkipReasonsUserConfig(Contract):
             checker = get_checker()
             assert checker.has_codemeta_file() is False
 
+    def test_has_conan_badge(self, mocker):
+        with mocker:
+            checker = get_checker()
+            assert checker.has_conan_badge() is False
+
     def test_has_conda_badge(self, mocker):
         with mocker:
             checker = get_checker()

--- a/tests/case1/gitlab/snippets/cli-no-args.txt
+++ b/tests/case1/gitlab/snippets/cli-no-args.txt
@@ -11,6 +11,7 @@ Proceeding without it -- expect the compliance to suffer.
 (3/5) registry
       × has_ascl_badge
       × has_bintray_badge
+      × has_conan_badge
       × has_conda_badge
       × has_cran_badge
       × has_crates_badge

--- a/tests/case1/gitlab/snippets/cli-with-nonexistent-path.txt
+++ b/tests/case1/gitlab/snippets/cli-with-nonexistent-path.txt
@@ -12,6 +12,7 @@ Proceeding without it -- expect the compliance to suffer.
 (3/5) registry
       × has_ascl_badge
       × has_bintray_badge
+      × has_conan_badge
       × has_conda_badge
       × has_cran_badge
       × has_crates_badge

--- a/tests/case1/gitlab/test_checker_no_args.py
+++ b/tests/case1/gitlab/test_checker_no_args.py
@@ -69,6 +69,11 @@ class TestCheckerNoArgs(Contract):
             checker = get_checker()
             assert checker.has_codemeta_file() is False
 
+    def test_has_conan_badge(self, mocker):
+        with mocker:
+            checker = get_checker()
+            assert checker.has_conan_badge() is False
+
     def test_has_conda_badge(self, mocker):
         with mocker:
             checker = get_checker()

--- a/tests/case1/gitlab/test_checker_with_emptyreasons_user_config.py
+++ b/tests/case1/gitlab/test_checker_with_emptyreasons_user_config.py
@@ -82,6 +82,11 @@ class TestCheckerWithEmptyReasonsUserConfig(Contract):
             checker = get_checker()
             assert checker.has_codemeta_file() is False
 
+    def test_has_conan_badge(self, mocker):
+        with mocker:
+            checker = get_checker()
+            assert checker.has_conan_badge() is False
+
     def test_has_conda_badge(self, mocker):
         with mocker:
             checker = get_checker()

--- a/tests/case1/gitlab/test_checker_with_skipreasons_user_config.py
+++ b/tests/case1/gitlab/test_checker_with_skipreasons_user_config.py
@@ -82,6 +82,11 @@ class TestCheckerWithSkipReasonsUserConfig(Contract):
             checker = get_checker()
             assert checker.has_codemeta_file() is False
 
+    def test_has_conan_badge(self, mocker):
+        with mocker:
+            checker = get_checker()
+            assert checker.has_conan_badge() is False
+
     def test_has_conda_badge(self, mocker):
         with mocker:
             checker = get_checker()

--- a/tests/case2/github/snippets/cli-no-args.txt
+++ b/tests/case2/github/snippets/cli-no-args.txt
@@ -7,6 +7,7 @@ url: https://github.com/fair-software/repo1
 (3/5) registry
       ✓ has_ascl_badge
       ✓ has_bintray_badge
+      ✓ has_conan_badge
       ✓ has_conda_badge
       ✓ has_cran_badge
       ✓ has_crates_badge

--- a/tests/case2/github/snippets/cli-with-nonexistent-path.txt
+++ b/tests/case2/github/snippets/cli-with-nonexistent-path.txt
@@ -12,6 +12,7 @@ Proceeding without it -- expect the compliance to suffer.
 (3/5) registry
       × has_ascl_badge
       × has_bintray_badge
+      × has_conan_badge
       × has_conda_badge
       × has_cran_badge
       × has_crates_badge

--- a/tests/case2/github/test_checker_no_args.py
+++ b/tests/case2/github/test_checker_no_args.py
@@ -69,6 +69,11 @@ class TestCheckerNoArgs(Contract):
             checker = get_checker()
             assert checker.has_codemeta_file() is True
 
+    def test_has_conan_badge(self, mocker):
+        with mocker:
+            checker = get_checker()
+            assert checker.has_conan_badge() is True
+
     def test_has_conda_badge(self, mocker):
         with mocker:
             checker = get_checker()

--- a/tests/case2/github/test_checker_with_emptyreasons_user_config.py
+++ b/tests/case2/github/test_checker_with_emptyreasons_user_config.py
@@ -82,6 +82,11 @@ class TestCheckerWithEmptyReasonsUserConfig(Contract):
             checker = get_checker()
             assert checker.has_codemeta_file() is True
 
+    def test_has_conan_badge(self, mocker):
+        with mocker:
+            checker = get_checker()
+            assert checker.has_conan_badge() is True
+
     def test_has_conda_badge(self, mocker):
         with mocker:
             checker = get_checker()

--- a/tests/case2/github/test_checker_with_skipreasons_user_config.py
+++ b/tests/case2/github/test_checker_with_skipreasons_user_config.py
@@ -82,6 +82,11 @@ class TestCheckerWithSkipReasonsUserConfig(Contract):
             checker = get_checker()
             assert checker.has_codemeta_file() is True
 
+    def test_has_conan_badge(self, mocker):
+        with mocker:
+            checker = get_checker()
+            assert checker.has_conan_badge() is True
+
     def test_has_conda_badge(self, mocker):
         with mocker:
             checker = get_checker()

--- a/tests/case2/gitlab/snippets/cli-no-args.txt
+++ b/tests/case2/gitlab/snippets/cli-no-args.txt
@@ -7,6 +7,7 @@ url: https://gitlab.com/fair-software/repo1
 (3/5) registry
       ✓ has_ascl_badge
       ✓ has_bintray_badge
+      ✓ has_conan_badge
       ✓ has_conda_badge
       ✓ has_cran_badge
       ✓ has_crates_badge

--- a/tests/case2/gitlab/snippets/cli-with-nonexistent-path.txt
+++ b/tests/case2/gitlab/snippets/cli-with-nonexistent-path.txt
@@ -12,6 +12,7 @@ Proceeding without it -- expect the compliance to suffer.
 (3/5) registry
       × has_ascl_badge
       × has_bintray_badge
+      × has_conan_badge
       × has_conda_badge
       × has_cran_badge
       × has_crates_badge

--- a/tests/case2/gitlab/test_checker_no_args.py
+++ b/tests/case2/gitlab/test_checker_no_args.py
@@ -69,6 +69,11 @@ class TestCheckerNoArgs(Contract):
             checker = get_checker()
             assert checker.has_codemeta_file() is True
 
+    def test_has_conan_badge(self, mocker):
+        with mocker:
+            checker = get_checker()
+            assert checker.has_conan_badge() is True
+
     def test_has_conda_badge(self, mocker):
         with mocker:
             checker = get_checker()

--- a/tests/case2/repo-files/README.rst
+++ b/tests/case2/repo-files/README.rst
@@ -24,3 +24,5 @@
       :target: https://npmjs.org/package/cnpm
 12. .. image:: https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F-green
       :target: https://fair-software.eu
+13. .. image:: https://img.shields.io/conan/v/vir-simd
+      :target: https://conan.io/center/recipes/vir-simd

--- a/tests/contracts/checker.py
+++ b/tests/contracts/checker.py
@@ -49,6 +49,10 @@ class Contract(ABC):
         pass
 
     @abstractmethod
+    def test_has_conan_badge(self, mocked_context: Mocker):
+        pass
+
+    @abstractmethod
     def test_has_conda_badge(self, mocked_context: Mocker):
         pass
 


### PR DESCRIPTION
conan.io is listed as an awesome research software registry: https://github.com/NLeSC/awesome-research-software-registries

Adjust tests and expected test output.

## Checklist

- [x] Code follows the [contributing guidelines](CONTRIBUTING.rst) of the project
- [x] This PR solves an existing issue and provided solution was discussed
- [x] The fix has been locally tested
- [x] Code follows the project's coding standards
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] The documentation has been updated to reflect the new feature

## List of related issues or pull requests

- #368

## Briefly describe the changes made in this pull request

Recognize Conan badge as proper software registry.

## Additional Notes

@c-martinez ping

## Instructions to review the pull request

Execute `pytest` as documented in the README. https://github.com/mattkretz/vir-simd is an example repo with Conan badge.