### PR TITLE
Attempt to support subgroups on gitlab

### DIFF
--- a/howfairis/repo.py
+++ b/howfairis/repo.py
@@ -69,7 +69,7 @@ class Repo:
         if self.platform == Platform.GITHUB:
             api = f"https://api.github.com/repos/{self.owner}/{self.repo}"
         elif self.platform == Platform.GITLAB:
-            api = f"https://gitlab.com/api/v4/projects/{self.owner.replace("/","%2F")}%2F{self.repo}"
+            api = f"https://gitlab.com/api/v4/projects/{self.owner.replace('/','%2F')}%2F{self.repo}"
         return api
 
     def _derive_reuse_url(self):

--- a/howfairis/repo.py
+++ b/howfairis/repo.py
@@ -69,7 +69,7 @@ class Repo:
         if self.platform == Platform.GITHUB:
             api = f"https://api.github.com/repos/{self.owner}/{self.repo}"
         elif self.platform == Platform.GITLAB:
-            api = f"https://gitlab.com/api/v4/projects/{self.owner}%2F{self.repo}"
+            api = f"https://gitlab.com/api/v4/projects/{self.owner.replace("/","%2F")}%2F{self.repo}"
         return api
 
     def _derive_reuse_url(self):
@@ -88,9 +88,8 @@ class Repo:
 
         elif self.platform == Platform.GITLAB:
             try:
-                owner, repo = (
-                    self.url.replace("https://gitlab.com", "").strip("/").split("/")[:2]
-                )
+                owner = '/'.join(self.url.replace("https://gitlab.com", "").strip("/").split("/")[0:-1])
+                repo = self.url.replace("https://gitlab.com", "").strip("/").split("/")[-1:][0]
             except ValueError as ex:
                 raise ValueError("Bad value for input argument URL.") from ex
 

--- a/livetests/test_cli.py
+++ b/livetests/test_cli.py
@@ -22,6 +22,15 @@ def test_valid_gitlab_url_unauthenticated():
     assert actual_exit_code == expected_exit_code
 
 
+def test_valid_gitlab_group_url_unauthenticated():
+    assert os.getenv("APIKEY_GITLAB") is None, "This test should run unauthenticated"
+    runner = CliRunner()
+    result = runner.invoke(cli, ["https://gitlab.com/hifis/hifis-workshops/make-your-code-ready-for-publication/astronaut-analysis"])
+    assert (
+        "url: https://gitlab.com/hifis/hifis-workshops/make-your-code-ready-for-publication/astronaut-analysis\n(1/5) repository" in result.stdout
+    ), "Did not find expected string"
+
+
 def test_invalid_url():
     runner = CliRunner()
     result = runner.invoke(cli, ["howfairis"])


### PR DESCRIPTION
## Checklist

- [ ] Code follows the [contributing guidelines](CONTRIBUTING.rst) of the project
- [x] This PR solves an existing issue ~and provided solution was discussed~
- [x] The fix has been locally tested
- [x] Code follows the project's coding standards
- [ ] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [ ] The documentation has been updated to reflect the new feature

## List of related issues or pull requests

- #328

## Briefly describe the changes made in this pull request

I would hope the only change necessary was to allow for longer paths with more 'directories'. That way, the 'owner' becomes a longer path instead of a single user/group.

## Additional Notes

Tested on one of our local gitlab instances and with `https://gitlab.com/hifis/hifis-workshops/make-your-code-ready-for-publication/astronaut-analysis`. The latter repository has been added to the livetests.

I don't think changes to the documentation are necessary.

## Instructions to review the pull request

```shell
# make a new temporary directory and cd into it
cd $(mktemp -d --tmpdir howfairis.XXXXXX)

# get a copy of the repo
git clone https://github.com/fair-software/howfairis .

# checkout the work from this branch 
git checkout <this branch>

# create a virtual environment named venv3
python3 -m venv venv3

# activate the virtual environment
source venv3/bin/activate

# update pip and friends
python3 -m pip install --upgrade pip wheel setuptools

# install runtime dependencies
python3 -m pip install .

# and, if you need it, the development tools
python3 -m pip install .[dev]
```

Keep what you need from below, extend as necessary

```shell
# run the unit tests
pytest

# tests against a live infrastructure
howfairis https://gitlab.com/hifis/hifis-workshops/make-your-code-ready-for-publication/astronaut-analysis
```

