### PR TITLE
Attempt to support self-managed GitLab instances

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -248,7 +248,6 @@ Which then shows something like:
       * https://github.com
 
       * https://gitlab.com
-      * https://gitlab.com
 
       * a self-hosted GitLab instance (provided the required features are
         supported, expect errors). The instance needs to be supplied as option.

--- a/README.rst
+++ b/README.rst
@@ -99,8 +99,7 @@ you should be able to call the executable, like so:
 3. self-hosted GitLab instances
 
 Self-hosted GitLab instances will rely on the required features being supported,
-expect errors if this is not the case. The instance needs to be supplied as
-command line option.
+expect errors if this is not the case.
 
 Docker
 ---------------
@@ -250,7 +249,7 @@ Which then shows something like:
       * https://gitlab.com
 
       * a self-hosted GitLab instance (provided the required features are
-        supported, expect errors). The instance needs to be supplied as option.
+        supported, expect errors)
 
     Options:
       -b, --branch TEXT               Which git branch to use. Also accepts other
@@ -266,10 +265,10 @@ Which then shows something like:
       -i, --ignore-repo-config        Ignore any configuration files on the
                                       remote.
 
-      -s, --self-hosted TEXT          URL of a self-hosted GitLab instance to use.
-                                      This may not work, depending on the server
-                                      version. Expect errors if unsupported
-                                      features are requried.
+      -s, --self-hosted               Use a self-hosted GitLab instance, guessing
+                                      the FQDN to use. This may not work,
+                                      depending on the server version. Expect
+                                      errors if unsupported features are requried.
 
       -p, --path TEXT                 Relative path (on the remote). Use this if
                                       you want howfairis to look for a README and

--- a/README.rst
+++ b/README.rst
@@ -95,18 +95,23 @@ you should be able to call the executable, like so:
 ``howfairis`` supports URLs from the following code repository platforms:
 
 1. ``https://github.com``
-2. ``https://gitlab.com`` (not including self-hosted instances)
+2. ``https://gitlab.com``
+3. self-hosted GitLab instances
+
+Self-hosted GitLab instances will rely on the required features being supported,
+expect errors if this is not the case. The instance needs to be supplied as
+command line option.
 
 Docker
 ---------------
 
-You can run howfairis Docker image using the command below.
+There is a howfairis Docker image that can be obtrained using the command below.
 
 .. code:: console
 
     docker pull fairsoftware/howfairis
 
-You can run howfairis Docker image using the command below.
+You can then run the howfairis Docker image using the command below.
 
 .. code:: console
 
@@ -242,7 +247,11 @@ Which then shows something like:
 
       * https://github.com
 
-      * https://gitlab.com (not including any self-hosted instances)
+      * https://gitlab.com
+      * https://gitlab.com
+
+      * a self-hosted GitLab instance (provided the required features are
+        supported, expect errors). The instance needs to be supplied as option.
 
     Options:
       -b, --branch TEXT               Which git branch to use. Also accepts other
@@ -257,6 +266,11 @@ Which then shows something like:
       -d, --show-default-config       Show default configuration and exit.
       -i, --ignore-repo-config        Ignore any configuration files on the
                                       remote.
+
+      -s, --self-hosted TEXT          URL of a self-hosted GitLab instance to use.
+                                      This may not work, depending on the server
+                                      version. Expect errors if unsupported
+                                      features are requried.
 
       -p, --path TEXT                 Relative path (on the remote). Use this if
                                       you want howfairis to look for a README and

--- a/howfairis/cli/cli.py
+++ b/howfairis/cli/cli.py
@@ -24,8 +24,8 @@ from howfairis.repo import Repo
               help="Show default configuration and exit.")
 @click.option("-i", "--ignore-repo-config", default=False, is_flag=True,
               help="Ignore any configuration files on the remote.")
-@click.option("-s", "--self-managed", default=None, type=click.STRING,
-              help="URL of a self-managed GitLab instance to use. This may not work, depending on the "
+@click.option("-s", "--self-hosted", default=None, type=click.STRING,
+              help="URL of a self-hosted GitLab instance to use. This may not work, depending on the "
                    "server version. Expect errors if unsupported features are requried.")
 @click.option("-p", "--path", default=None, type=click.STRING,
               help="Relative path (on the remote). Use this if you want howfairis to look for a "
@@ -43,7 +43,7 @@ from howfairis.repo import Repo
 @click.option("-v", "--version", default=False, is_flag=True,
               help="Show version and exit.")
 @click.argument("url", required=False)
-def cli(url=None, branch=None, user_config_filename=None, repo_config_filename=None, self_managed=None, path=None,
+def cli(url=None, branch=None, user_config_filename=None, repo_config_filename=None, self_hosted=None, path=None,
         show_trace=False, json_output=False, version=False, ignore_repo_config=False, show_default_config=False, quiet=False):
 
     """Determine compliance with recommendations from fair-software.eu for the repository at URL. The following
@@ -72,9 +72,9 @@ def cli(url=None, branch=None, user_config_filename=None, repo_config_filename=N
         quiet = True
 
     init_terminal_colors()
-    repo = Repo(url, branch, self_managed, path)
+    repo = Repo(url, branch, self_hosted, path)
 
-    print_feedback_about_repo_args(url, branch, self_managed, path, is_quiet=quiet)
+    print_feedback_about_repo_args(url, branch, self_hosted, path, is_quiet=quiet)
     print_feedback_about_config_args(ignore_repo_config, repo_config_filename,
                                      user_config_filename, is_quiet=quiet)
 

--- a/howfairis/cli/cli.py
+++ b/howfairis/cli/cli.py
@@ -24,8 +24,8 @@ from howfairis.repo import Repo
               help="Show default configuration and exit.")
 @click.option("-i", "--ignore-repo-config", default=False, is_flag=True,
               help="Ignore any configuration files on the remote.")
-@click.option("-s", "--self-hosted", default=None, type=click.STRING,
-              help="URL of a self-hosted GitLab instance to use. This may not work, depending on the "
+@click.option("-s", "--self-hosted", default=False, is_flag=True,
+              help="Use a self-hosted GitLab instance, guessing the FQDN to use. This may not work, depending on the "
                    "server version. Expect errors if unsupported features are requried.")
 @click.option("-p", "--path", default=None, type=click.STRING,
               help="Relative path (on the remote). Use this if you want howfairis to look for a "
@@ -43,7 +43,7 @@ from howfairis.repo import Repo
 @click.option("-v", "--version", default=False, is_flag=True,
               help="Show version and exit.")
 @click.argument("url", required=False)
-def cli(url=None, branch=None, user_config_filename=None, repo_config_filename=None, self_hosted=None, path=None,
+def cli(url=None, branch=None, user_config_filename=None, repo_config_filename=None, self_hosted=False, path=None,
         show_trace=False, json_output=False, version=False, ignore_repo_config=False, show_default_config=False, quiet=False):
 
     """Determine compliance with recommendations from fair-software.eu for the repository at URL. The following
@@ -53,8 +53,7 @@ def cli(url=None, branch=None, user_config_filename=None, repo_config_filename=N
 
     * https://gitlab.com
 
-    * a self-hosted GitLab instance (provided the required features are supported, expect errors).
-    The instance needs to be supplied as option.
+    * a self-hosted GitLab instance (provided the required features are supported, expect errors)
     """
 
     if show_trace is False:

--- a/howfairis/cli/print_feedback_about_repo_args.py
+++ b/howfairis/cli/print_feedback_about_repo_args.py
@@ -1,4 +1,4 @@
-def print_feedback_about_repo_args(url, branch, self_managed, path, is_quiet=False):
+def print_feedback_about_repo_args(url, branch, self_hosted, path, is_quiet=False):
     """  """
 
     assert url is not None, "Expected URL to not be emtpy."
@@ -9,8 +9,8 @@ def print_feedback_about_repo_args(url, branch, self_managed, path, is_quiet=Fal
         if url is not None:
             print("url: " + url)
 
-        if self_managed is not None:
-            print("self-managed instance: " + self_managed)
+        if self_hosted is not None:
+            print("self-hosted instance: " + self_hosted)
 
         if branch is not None:
             print("branch: " + branch)

--- a/howfairis/cli/print_feedback_about_repo_args.py
+++ b/howfairis/cli/print_feedback_about_repo_args.py
@@ -1,4 +1,4 @@
-def print_feedback_about_repo_args(url, branch, path, is_quiet=False):
+def print_feedback_about_repo_args(url, branch, self_managed, path, is_quiet=False):
     """  """
 
     assert url is not None, "Expected URL to not be emtpy."
@@ -8,6 +8,9 @@ def print_feedback_about_repo_args(url, branch, path, is_quiet=False):
 
         if url is not None:
             print("url: " + url)
+
+        if self_managed is not None:
+            print("self-managed instance: " + self_managed)
 
         if branch is not None:
             print("branch: " + branch)

--- a/howfairis/cli/print_feedback_about_repo_args.py
+++ b/howfairis/cli/print_feedback_about_repo_args.py
@@ -9,8 +9,8 @@ def print_feedback_about_repo_args(url, branch, self_hosted, path, is_quiet=Fals
         if url is not None:
             print("url: " + url)
 
-        if self_hosted is not None:
-            print("self-hosted instance: " + self_hosted)
+        if self_hosted:
+            print("using self-hosted instance")
 
         if branch is not None:
             print("branch: " + branch)

--- a/howfairis/mixins/license_mixin.py
+++ b/howfairis/mixins/license_mixin.py
@@ -41,7 +41,7 @@ class LicenseMixin:
             result = True
 
         if self.repo.platform == Platform.GITLAB:
-            url = f"https://gitlab.com/{self.repo.owner}/{self.repo.repo}"
+            url = f"https://{self.repo.instance}/{self.repo.owner}/{self.repo.repo}"
 
             try:
                 response = get_from_platform(

--- a/howfairis/repo.py
+++ b/howfairis/repo.py
@@ -16,13 +16,13 @@ class Repo:
         url: URL of a code repository such as https://github.com/fair-software/howfairis
         branch: Branch to checkout. Defaults to default branch of the repository.
             Can also be a commit SHA-1 hash or tag.
-        self_managed: FQHN of self-managed GitLab instance such as my.gitlab.tld
+        self_hosted: FQHN of self-hosted GitLab instance such as my.gitlab.tld
         path: Path inside repository. Defaults to root.
 
     Attributes:
         url (str): URL of a code repository,
         branch (str, None): Branch to checkout. If None then :attr:`Repo.default_branch` will be used.
-        instance (str, None): FQHN of a self-managed GitLab instance. If None then assume 'gitlab.com'.
+        instance (str, None): FQHN of a self-hosted GitLab instance. If None then assume 'gitlab.com'.
         path (str): Path inside repository.
         platform (.code_repository_platforms.Platform): Detected code repository platform of repo.
         owner (str): Owner of the repo.
@@ -36,16 +36,18 @@ class Repo:
 
     # pylint: disable=too-many-instance-attributes
     def __init__(
-        self, url: str, branch: Optional[str] = None, self_managed: Optional[str] = None, path: Optional[str] = None
+        self, url: str, branch: Optional[str] = None,
+        self_hosted: Optional[str] = None,
+        path: Optional[str] = None
     ):
 
         # run assertions on user input
-        Repo._check_assertions(url, self_managed)
+        Repo._check_assertions(url, self_hosted)
 
         # assign arguments to instance members
         self.url = url
         self.branch = branch
-        self.instance = "gitlab.com" if self_managed is None else self_managed
+        self.instance = "gitlab.com" if self_hosted is None else self_hosted
         self.path = "" if path is None else "/" + path.strip("/")
 
         # assign remaining members as needed
@@ -58,17 +60,17 @@ class Repo:
         self.reuse_url = self._derive_reuse_url()
 
     @staticmethod
-    def _check_assertions(url, self_managed = None):
-        self_managed = "gitlab.com" if self_managed is None else self_managed
-        assert not self_managed.startswith("https://"), "self-managed instance should be provided without https://"
+    def _check_assertions(url, self_hosted):
+        self_hosted = "gitlab.com" if self_hosted is None else self_hosted
+        assert not self_hosted.startswith("https://"), "self-hosted instance should be provided without https://"
         assert url.startswith("https://"), "URL should start with https://"
         assert True in [
             url.startswith("https://github.com"),
-            url.startswith(f"https://{self_managed}"),
-        ], f"Repository should be on github.com or on {self_managed}."
+            url.startswith(f"https://{self_hosted}"),
+        ], f"Repository should be on github.com or on {self_hosted}."
         assert (
             re.search("^https://git(hub|lab).com/[^/]+/[^/]+", url) or
-            re.search("^https://"+self_managed+"/[^/]+/[^/]+", url)
+            re.search("^https://"+self_hosted+"/[^/]+/[^/]+", url)
         ), f"URL is not a repository ({url})."
 
     def _derive_api(self):

--- a/howfairis/repo.py
+++ b/howfairis/repo.py
@@ -63,7 +63,7 @@ class Repo:
     def _check_assertions(url, self_hosted):
         self_hosted = "gitlab.com" if self_hosted is None else self_hosted
         assert not self_hosted.startswith("https://"), "self-hosted instance should be provided without https://"
-        assert url.startswith("https://"), "URL should start with https://"
+        assert url.startswith("https://"), "url should start with https://"
         assert True in [
             url.startswith("https://github.com"),
             url.startswith(f"https://{self_hosted}"),
@@ -71,7 +71,7 @@ class Repo:
         assert (
             re.search("^https://git(hub|lab).com/[^/]+/[^/]+", url) or
             re.search("^https://"+self_hosted+"/[^/]+/[^/]+", url)
-        ), f"URL is not a repository ({url})."
+        ), f"url is not a repository"
 
     def _derive_api(self):
         if self.platform == Platform.GITHUB:

--- a/howfairis/repo.py
+++ b/howfairis/repo.py
@@ -16,13 +16,13 @@ class Repo:
         url: URL of a code repository such as https://github.com/fair-software/howfairis
         branch: Branch to checkout. Defaults to default branch of the repository.
             Can also be a commit SHA-1 hash or tag.
-        self_hosted: FQHN of self-hosted GitLab instance such as my.gitlab.tld
+        self_hosted: FQDN of self-hosted GitLab instance such as my.gitlab.tld
         path: Path inside repository. Defaults to root.
 
     Attributes:
         url (str): URL of a code repository,
         branch (str, None): Branch to checkout. If None then :attr:`Repo.default_branch` will be used.
-        instance (str, None): FQHN of a self-hosted GitLab instance. If None then assume 'gitlab.com'.
+        instance (str, None): FQDN of a self-hosted GitLab instance. If None then assume 'gitlab.com'.
         path (str): Path inside repository.
         platform (.code_repository_platforms.Platform): Detected code repository platform of repo.
         owner (str): Owner of the repo.

--- a/howfairis/repo.py
+++ b/howfairis/repo.py
@@ -16,13 +16,13 @@ class Repo:
         url: URL of a code repository such as https://github.com/fair-software/howfairis
         branch: Branch to checkout. Defaults to default branch of the repository.
             Can also be a commit SHA-1 hash or tag.
-        self_hosted: FQDN of self-hosted GitLab instance such as my.gitlab.tld
+        self_hosted: Flag if self-hosted GitLab instance such as my.gitlab.tld is used
         path: Path inside repository. Defaults to root.
 
     Attributes:
         url (str): URL of a code repository,
         branch (str, None): Branch to checkout. If None then :attr:`Repo.default_branch` will be used.
-        instance (str, None): FQDN of a self-hosted GitLab instance. If None then assume 'gitlab.com'.
+        instance (str): FQDN of a self-hosted GitLab instance. 'gitlab.com' by default.
         path (str): Path inside repository.
         platform (.code_repository_platforms.Platform): Detected code repository platform of repo.
         owner (str): Owner of the repo.
@@ -37,7 +37,7 @@ class Repo:
     # pylint: disable=too-many-instance-attributes
     def __init__(
         self, url: str, branch: Optional[str] = None,
-        self_hosted: Optional[str] = None,
+        self_hosted: Optional[bool] = False,
         path: Optional[str] = None
     ):
 
@@ -47,7 +47,7 @@ class Repo:
         # assign arguments to instance members
         self.url = url
         self.branch = branch
-        self.instance = "gitlab.com" if self_hosted is None else self_hosted
+        self.instance = "gitlab.com" if not self_hosted else urlparse(url).netloc
         self.path = "" if path is None else "/" + path.strip("/")
 
         # assign remaining members as needed
@@ -61,17 +61,21 @@ class Repo:
 
     @staticmethod
     def _check_assertions(url, self_hosted):
-        self_hosted = "gitlab.com" if self_hosted is None else self_hosted
-        assert not self_hosted.startswith("https://"), "self-hosted instance should be provided without https://"
         assert url.startswith("https://"), "url should start with https://"
-        assert True in [
-            url.startswith("https://github.com"),
-            url.startswith(f"https://{self_hosted}"),
-        ], f"Repository should be on github.com or on {self_hosted}."
+        if self_hosted:
+            assert False in [
+                url.startswith("https://github.com"),
+                url.startswith("https://gitlab.com"),
+            ], f"Repository should be on self-hosted GitLab."
+        else:
+            assert True in [
+                url.startswith("https://github.com"),
+                url.startswith(f"https://gitlab.com"),
+            ], f"Repository should be on github.com or on gitlab.com."
         assert (
             re.search("^https://git(hub|lab).com/[^/]+/[^/]+", url) or
-            re.search("^https://"+self_hosted+"/[^/]+/[^/]+", url)
-        ), f"url is not a repository"
+            re.search("^https://"+urlparse(url).netloc+"/[^/]+/[^/]+", url)
+        ), "url is not a repository"
 
     def _derive_api(self):
         if self.platform == Platform.GITHUB:


### PR DESCRIPTION
## Checklist

- [ ] Code follows the [contributing guidelines](CONTRIBUTING.rst) of the project
- [x] This PR solves an existing issue ~and provided solution was discussed~
- [x] The fix has been locally tested
- [x] Code follows the project's coding standards
- [ ] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] The documentation has been updated to reflect the new feature

## List of related issues or pull requests

- #69

## Briefly describe the changes made in this pull request

An additional command line option has been introduced to supply a self-hosted GitLab instance. I think this is necessary since only URLs that contain `gitlab.com` or `github.com` clearly identify a platform, self-hosted GitLab instances can have arbitrary names. Assertions have been adjusted to hopefully catch wrong command line options. Instead of using `gitlab.com` as URL/hostname for any subsequent calls, `self.instance` will be used instead.
The supplied instance is then used as FQDN for `self.instance`, if no instance is supplied, default to `gitlab.com` for the GitLab platform.

## Additional Notes

I agree with the technical obstacles stated in the issue, but my hope is there is only an advantage with this change. It should work better than not at all. I cannot judge if it will result in a bad user experience if errors do happen with instances that would not support the API calls made.

Tested with our local GitLab instance.

## Instructions to review the pull request

```shell
# make a new temporary directory and cd into it
cd $(mktemp -d --tmpdir howfairis.XXXXXX)

# get a copy of the repo
git clone https://github.com/fair-software/howfairis .

# checkout the work from this branch 
git checkout <this branch>

# create a virtual environment named venv3
python3 -m venv venv3

# activate the virtual environment
source venv3/bin/activate

# update pip and friends
python3 -m pip install --upgrade pip wheel setuptools

# install runtime dependencies
python3 -m pip install .

# and, if you need it, the development tools
python3 -m pip install .[dev]
```

Keep what you need from below, extend as necessary

```shell
# run the unit tests
pytest

# tests against a live infrastructure
howfairis -s gitlab.jsc.fz-juelich.de https://gitlab.jsc.fz-juelich.de/cla-bot-development/cla-bot
```

